### PR TITLE
Added flags for App insights and HTTPS

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -67,7 +67,6 @@ services:
       DB_USER: postgres
       DB_PASSWORD: mysecretpassword
       DB_NAME: dialogporten
-      IS_LOCAL: true
       PORT: 3000
       DEV_ENV: dev
       REDIRECT_URI: http://localhost:3000/auth/cb

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -16,7 +16,7 @@
     "dev": "concurrently \"npx tsc --watch\" \"nodemon --watch 'src/**/*.ts'\"",
     "docker": "concurrently \"npx tsc --watch\" \"nodemon --watch '/app/packages/bff/src/**/*.ts'\"",
     "build:docker": "docker build -f ./Dockerfile -t bff ../..",
-    "run:docker": "docker run -e IS_LOCAL=true -it -p 80:80 bff"
+    "run:docker": "docker run -e -it -p 80:80 bff"
   },
   "dependencies": {
     "@azure/app-configuration": "^1.4.1",

--- a/packages/bff/src/index.ts
+++ b/packages/bff/src/index.ts
@@ -1,9 +1,6 @@
 export const bffVersion = process.env.GIT_SHA || 'v6.1.5';
-export const isLocal = process.env.IS_LOCAL === 'true';
 import './config/env';
 
-if (process.env.IS_LOCAL === 'true')
-  console.log(`Starting BFF ${bffVersion} in local mode with env file '${process.env.ENV_FILE}'.`);
 import express, { Express } from 'express';
 import bodyParser from 'body-parser';
 import 'reflect-metadata';
@@ -43,7 +40,7 @@ const main = async (): Promise<void> => {
   });
 
   // ************ INITIALIZE APPLICATION INSIGHTS ************
-  if (!isLocal) {
+  if (process.env.ENABLE_APP_INSIGHTS === 'true') {
     const { initAppInsights } = await import('./util/ApplicationInsightsInit');
     await initAppInsights();
     console.log(`Starting BFF ${bffVersion} with GIT SHA: ${process.env.GIT_SHA}.`);

--- a/packages/bff/src/util/ApplicationInsightsInit.ts
+++ b/packages/bff/src/util/ApplicationInsightsInit.ts
@@ -4,29 +4,29 @@ import { bffVersion } from '..';
 import { waitNSeconds } from './waitNSeconds';
 
 export const initAppInsights = async () => {
-  // Setup Application Insights:
-  return new Promise(async (resolve, reject) => {
-    if (!process.env.APPLICATIONINSIGHTS_CONNECTION_STRING)
-      reject("No APPLICATIONINSIGHTS_CONNECTION_STRING found in env, can't initialize appInsights");
-    appInsights
-      .setup(process.env.APPLICATIONINSIGHTS_CONNECTION_STRING)
-      .setAutoDependencyCorrelation(true)
-      .setAutoCollectRequests(true)
-      .setAutoCollectPerformance(true, true)
-      .setAutoCollectExceptions(true)
-      .setAutoCollectDependencies(true)
-      .setAutoCollectConsole(true, true)
-      .setUseDiskRetryCaching(true)
-      .setSendLiveMetrics(false)
-      // .setInternalLogging(true, true)
-      .setDistributedTracingMode(appInsights.DistributedTracingModes.AI_AND_W3C)
-      .start();
-    await waitNSeconds(1);
-    if (appInsights.defaultClient) {
-      console.log(bffVersion, ': ', 'AppInsights initialized properly.');
-    } else {
-      console.error(bffVersion, ': ', 'AppInsights failed to initialize properly.');
-    }
-    resolve('Done');
-  });
+  if (process.env.ENABLE_APP_INSIGHTS === 'true') {
+    return new Promise((resolve, reject) => {
+      if (!process.env.APPLICATIONINSIGHTS_CONNECTION_STRING)
+        reject("No APPLICATIONINSIGHTS_CONNECTION_STRING found in env, can't initialize appInsights");
+      appInsights
+        .setup(process.env.APPLICATIONINSIGHTS_CONNECTION_STRING)
+        .setAutoDependencyCorrelation(true)
+        .setAutoCollectRequests(true)
+        .setAutoCollectPerformance(true, true)
+        .setAutoCollectExceptions(true)
+        .setAutoCollectDependencies(true)
+        .setAutoCollectConsole(true, true)
+        .setUseDiskRetryCaching(true)
+        .setSendLiveMetrics(false)
+        .setDistributedTracingMode(appInsights.DistributedTracingModes.AI_AND_W3C)
+        .start();
+      waitNSeconds(1);
+      if (appInsights.defaultClient) {
+        console.log(bffVersion, ': ', 'AppInsights initialized properly.');
+      } else {
+        console.error(bffVersion, ': ', 'AppInsights failed to initialize properly.');
+      }
+      resolve('Done');
+    });
+  }
 };

--- a/packages/bff/src/util/sessionUtils.ts
+++ b/packages/bff/src/util/sessionUtils.ts
@@ -1,15 +1,12 @@
 import { CookieOptions } from 'express';
 import session from 'express-session';
 import '../config/env';
-import { isLocal } from '..';
 
 export const setCookie = (res: any, value: string) => {
   const cookieName = process.env.COOKIE_NAME || 'cookieName';
   const options: CookieOptions = {
-    // maxAge: 1000 * 60 * 5, // Cookie will expire in 5 min
-    // maxAge not set means cookie will be removed when browser is closed
     httpOnly: true, // Cookie not accessible via client-side script
-    secure: process.env.IS_LOCAL === 'true' ? false : true, // Cookie will be sent only over HTTPS if set to true
+    secure: process.env.ENABLE_HTTPS === 'true' ? true : false, // Cookie will be sent only over HTTPS if set to true
   };
   res.cookie(cookieName, value, options);
 };
@@ -32,5 +29,5 @@ export const sessionMiddleware = session({
   secret: process.env.SESSION_SECRET || 'SecretHere',
   resave: false,
   saveUninitialized: false,
-  cookie: { maxAge: 30 * 24 * 60 * 60 * 1000, secure: isLocal ? false : true },
+  cookie: { maxAge: 30 * 24 * 60 * 60 * 1000, secure: process.env.ENABLE_HTTPS ? true : false },
 });


### PR DESCRIPTION
Application Insights started nå ved å sende inn ENABLE_APP_INSIGHTS = true env variabel, og HTTPS enables ved env var ENABLE_HTTPS=true.
Fjernet all bruk av isLocal variabel.

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

