### PR TITLE
doc: update info about linting config for Webstorm

### DIFF
--- a/packages/docs/docs/dev tools/formatting+linting.md
+++ b/packages/docs/docs/dev tools/formatting+linting.md
@@ -20,13 +20,13 @@ Go to **Settings** -> **Tools** -> **File Watcher**:
 3. Choose the file type for files to watch, e.g., `TypeScript JSX`.
 4. Scope: `Project Files`.
 5. Program: Specify the path to the Biome executable in your project, for example, `$ProjectFileDir$/node_modules/.pnpm/@biomejs+biome@1.5.3/node_modules/@biomejs/biome/bin/biome` (adjust the version as necessary).
-6. Arguments: `format --write $FilePath$`.
+6. Arguments: `check --apply --no-errors-on-unmatched $FileName$`.
 
 Alternatively, you can import this configuration:
 
 ```markdown
 <TaskOptions>
-  <option name="arguments" value="format --write $FilePath$" />
+  <option name="arguments" value="check --apply --no-errors-on-unmatched $FileName$" />
   <option name="checkSyntaxErrors" value="true" />
   <option name="description" />
   <option name="exitCodeBehavior" value="ALWAYS" />


### PR DESCRIPTION
Oppdaterer dokumentasjon om hvordan vi skal kjøre Biome med File Watcher in Webstorm.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->