### PR TITLE
fix: Storybook now correctly shows company layout

### DIFF
--- a/packages/storybook/src/stories/Sidebar/Sidebar.stories.tsx
+++ b/packages/storybook/src/stories/Sidebar/Sidebar.stories.tsx
@@ -90,7 +90,7 @@ const SidebarSimpleExamplePerson = () => {
 };
 
 const SidebarSimpleExampleCompany = () => {
-  return <Sidebar />;
+  return <Sidebar isCompany />;
 };
 
 export const simpleDesktopExamplePerson: () => JSX.Element = () => <SidebarSimpleExamplePerson />;


### PR DESCRIPTION
Bare en bugfix, var en bug som gjorde at Person og Bedrift så likt ut for Sidebar.


### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->