### PR TITLE
Feat/add grouping for inbox items

### DIFF
--- a/packages/frontend-design-poc/src/components/InboxItem/InboxItem.tsx
+++ b/packages/frontend-design-poc/src/components/InboxItem/InboxItem.tsx
@@ -5,12 +5,12 @@ import { Link } from 'react-router-dom';
 
 import styles from './inboxItem.module.css';
 
-interface Participant {
+export interface Participant {
   label: string;
   icon?: JSX.Element;
 }
 
-interface InboxItemTag {
+export interface InboxItemTag {
   label: string;
   icon?: JSX.Element;
   className?: string;

--- a/packages/frontend-design-poc/src/components/InboxItem/InboxItems.tsx
+++ b/packages/frontend-design-poc/src/components/InboxItem/InboxItems.tsx
@@ -18,6 +18,6 @@ interface InboxItemsProps {
  *
  */
 
-export const InboxItems = ({ children }: InboxItemsProps) => {
+export const InboxItems = ({ children }: InboxItemsProps): JSX.Element => {
   return <ul className={styles.inboxItems}>{children}</ul>;
 };

--- a/packages/frontend-design-poc/src/components/InboxItem/InboxItemsHeader.tsx
+++ b/packages/frontend-design-poc/src/components/InboxItem/InboxItemsHeader.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@digdir/designsystemet-react';
+import { CheckmarkIcon } from '@navikt/aksel-icons';
+import { useTranslation } from 'react-i18next';
+import styles from './inboxItemsHeader.module.css';
+
+interface InboxItemsHeaderProps {
+  title: string;
+  onSelectAll?: () => void;
+  hideSelectAll?: boolean;
+}
+
+/**
+ * `InboxItemsHeader` renders the header section of an inbox items list, including a title and an optional "Select All" button.
+ *
+ * @component
+ * @example
+ * const title = "Inbox"
+ * const onSelectAll = () => console.log("All items selected")
+ * return <InboxItemsHeader title={title} onSelectAll={onSelectAll} />
+ *
+ * @param {Object} props - Props for InboxItemsHeader
+ * @param {string} props.title - The title to be displayed in the header.
+ * @param {boolean} props.hideSelectAll - Optionally hide the select all button.
+ * @param {Function} [props.onSelectAll] - Optional callback function to be called when the "Select All" button is clicked.
+ */
+export const InboxItemsHeader = ({ title, onSelectAll, hideSelectAll = false }: InboxItemsHeaderProps) => {
+  const { t } = useTranslation();
+  return (
+    <header className={styles.inboxItemsHeader}>
+      <h2>{title}</h2>
+      {typeof onSelectAll === 'function' && !hideSelectAll && (
+        <Button size="small" onClick={onSelectAll} variant="secondary" color="second">
+          <CheckmarkIcon />
+          {t('inbox.heading.choose_all')}
+        </Button>
+      )}
+    </header>
+  );
+};

--- a/packages/frontend-design-poc/src/components/InboxItem/inboxItemsHeader.module.css
+++ b/packages/frontend-design-poc/src/components/InboxItem/inboxItemsHeader.module.css
@@ -1,0 +1,6 @@
+.inboxItemsHeader {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}

--- a/packages/frontend-design-poc/src/components/Sidebar/sidebar.module.css
+++ b/packages/frontend-design-poc/src/components/Sidebar/sidebar.module.css
@@ -3,7 +3,6 @@
     background-color: #E5EBEC;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
     padding: 1.25em 0;
 }
 

--- a/packages/frontend-design-poc/src/i18n/resources/nb.json
+++ b/packages/frontend-design-poc/src/i18n/resources/nb.json
@@ -4,6 +4,7 @@
   "inbox.title": "Innboks",
   "inbox.attachment.count": "{count, plural, =0 {Ingen vedlegg} one {# vedlegg} other {# vedlegg}}",
   "inbox.attachment.link": "Lenke som vedlegg",
+  "inbox.heading.choose_all": "Velg alle",
   "word.back": "Tilbake",
   "word.to": "til",
   "sidebar.drafts": "Utkast",

--- a/packages/frontend-design-poc/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend-design-poc/src/pages/Inbox/Inbox.tsx
@@ -8,17 +8,146 @@ import {
   StarIcon,
   TrashIcon,
 } from '@navikt/aksel-icons';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ActionPanel } from '../../components';
-import { InboxItem, InboxItems } from '../../components/InboxItem';
+import { ActionPanel, InboxItem, InboxItemTag, InboxItems, Participant } from '../../components';
+import { InboxItemsHeader } from '../../components/InboxItem/InboxItemsHeader.tsx';
 import styles from './inbox.module.css';
+
+interface Dialog {
+  checkboxValue: string;
+  title: string;
+  description: string;
+  sender: Participant;
+  receiver: Participant;
+  tags: InboxItemTag[];
+  linkTo: string;
+  date: string;
+}
 
 export const Inbox = () => {
   const { t } = useTranslation();
-  const [isChecked, setIsChecked] = useState<boolean>(false);
-  const [isChecked2, setIsChecked2] = useState<boolean>(false);
-  const selectedItemCount = [isChecked, isChecked2].filter(Boolean).length;
+  const [selectedItems, setSelectedItems] = useState<{
+    [key: string]: boolean;
+  }>({});
+  const selectedItemCount = Object.values(selectedItems).filter(Boolean).length;
+
+  const data: Dialog[] = [
+    {
+      checkboxValue: 'test',
+      title: 'Viktig melding',
+      description: 'Du har mottatt en viktig melding!',
+      sender: { label: 'Viktig bedrift', icon: <PersonSuitIcon /> },
+      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
+      tags: [
+        { label: 'hello', icon: <StarIcon /> },
+        { label: 'hallaz', icon: <SealIcon /> },
+      ],
+      linkTo: '/inbox/1',
+      date: '2023-08-15',
+    },
+    {
+      checkboxValue: 'test2',
+      title: 'Har du glemt oss?',
+      description: 'Det tror jeg du har!',
+      sender: { label: 'Viktig bedrift', icon: <PersonSuitIcon /> },
+      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
+      tags: [
+        { label: 'hello', icon: <StarIcon /> },
+        { label: 'hallaz', icon: <SealIcon /> },
+      ],
+      linkTo: '/inbox/2',
+      date: '2023-09-20',
+    },
+    {
+      checkboxValue: 'test3',
+      title: 'Årsrapport klar',
+      description: 'Din årsrapport for 2023 er nå tilgjengelig.',
+      sender: { label: 'Regnskapsfirmaet AS', icon: <PersonSuitIcon /> },
+      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
+      tags: [
+        { label: 'rapport', icon: <SealIcon /> },
+        { label: 'viktig', icon: <StarIcon /> },
+      ],
+      linkTo: '/inbox/3',
+      date: '2024-01-05',
+    },
+    {
+      checkboxValue: 'test4',
+      title: 'Oppdatering av vilkår',
+      description: 'Vilkårene for bruk av vår tjeneste er oppdatert.',
+      sender: { label: 'Tjeneste AS', icon: <PersonSuitIcon /> },
+      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
+      tags: [
+        { label: 'oppdatering', icon: <EnvelopeOpenIcon /> },
+        { label: 'vilkår', icon: <SealIcon /> },
+      ],
+      linkTo: '/inbox/4',
+      date: '2024-02-14',
+    },
+    {
+      checkboxValue: 'test5',
+      title: 'Invitasjon til webinar',
+      description: 'Du er invitert til vårt eksklusive webinar om fremtidens teknologi.',
+      sender: { label: 'Teknologi AS', icon: <PersonSuitIcon /> },
+      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
+      tags: [
+        { label: 'webinar', icon: <StarIcon /> },
+        { label: 'invitasjon', icon: <EnvelopeOpenIcon /> },
+      ],
+      linkTo: '/inbox/5',
+      date: '2024-03-10',
+    },
+    {
+      checkboxValue: 'test6',
+      title: 'Påminnelse om betaling',
+      description: 'Vennligst husk å betale faktura nr. 45677 innen 15.04.2023.',
+      sender: { label: 'Fakturaservice AS', icon: <PersonSuitIcon /> },
+      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
+      tags: [
+        { label: 'påminnelse', icon: <ClockDashedIcon /> },
+        { label: 'faktura', icon: <SealIcon /> },
+      ],
+      linkTo: '/inbox/6',
+      date: '2023-03-30',
+    },
+    {
+      checkboxValue: 'test7',
+      title: 'Velkommen som ny bruker!',
+      description: 'Vi ønsker deg velkommen som ny bruker og ser frem til et godt samarbeid.',
+      sender: { label: 'Velkomstteamet', icon: <PersonSuitIcon /> },
+      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
+      tags: [
+        { label: 'velkommen', icon: <StarIcon /> },
+        { label: 'ny bruker', icon: <EnvelopeOpenIcon /> },
+      ],
+      linkTo: '/inbox/7',
+      date: '2024-04-01',
+    },
+  ];
+
+  const dataGroupedByYear = useMemo(
+    () =>
+      data.reduce(
+        (acc: Record<string, Dialog[]>, item) => {
+          const year = String(new Date(item.date).getFullYear());
+          if (!acc[year]) {
+            acc[year] = [];
+          }
+          acc[year].push(item);
+          return acc;
+        },
+        {} as Record<string, Dialog[]>,
+      ),
+    [data],
+  );
+
+  const handleCheckedChange = (checkboxValue: string, checked: boolean) => {
+    setSelectedItems((prev: Record<string, boolean>) => ({
+      ...prev,
+      [checkboxValue]: checked,
+    }));
+  };
 
   return (
     <main>
@@ -45,49 +174,47 @@ export const Inbox = () => {
               },
             ]}
             selectedItemCount={selectedItemCount}
-            onUndoSelection={() => {
-              setIsChecked(false);
-              setIsChecked2(false);
-            }}
+            onUndoSelection={() => setSelectedItems({})}
           />
         </div>
       )}
-      <InboxItems>
-        <InboxItem
-          checkboxValue="test"
-          title="Viktig melding"
-          toLabel={t('word.to')}
-          description="Du har mottatt en viktig melding!"
-          sender={{ label: 'Viktig bedrift', icon: <PersonSuitIcon /> }}
-          receiver={{ label: 'Bruker Brukerson', icon: <PersonIcon /> }}
-          isChecked={isChecked}
-          onCheckedChange={(checked) => {
-            setIsChecked(checked);
-          }}
-          tags={[
-            { label: 'hello', icon: <StarIcon /> },
-            { label: 'hallaz', icon: <SealIcon /> },
-          ]}
-          linkTo="/inbox/1"
-        />
-        <InboxItem
-          checkboxValue="test2"
-          title="Har du glemt oss?"
-          toLabel={t('word.to')}
-          description="Det tror jeg du har!"
-          sender={{ label: 'Viktig bedrift', icon: <PersonSuitIcon /> }}
-          receiver={{ label: 'Bruker Brukerson', icon: <PersonIcon /> }}
-          isChecked={isChecked2}
-          onCheckedChange={(checked) => {
-            setIsChecked2(checked);
-          }}
-          tags={[
-            { label: 'hello', icon: <StarIcon /> },
-            { label: 'hallaz', icon: <SealIcon /> },
-          ]}
-          linkTo="/inbox/2"
-        />
-      </InboxItems>
+      <section>
+        {Object.entries(dataGroupedByYear).map(([year, items]) => {
+          const hideSelectAll = items.every((item) => selectedItems[item.checkboxValue]);
+          return (
+            <InboxItems key={year}>
+              <InboxItemsHeader
+                hideSelectAll={hideSelectAll}
+                onSelectAll={() => {
+                  const newItems = items
+                    .map((item) => ({ key: item.checkboxValue, checked: true }))
+                    .reduce((acc, item) => ({ ...acc, [item.key]: item.checked }), {});
+                  setSelectedItems({
+                    ...selectedItems,
+                    ...newItems,
+                  });
+                }}
+                title={year}
+              />
+              {items.map((item) => (
+                <InboxItem
+                  key={item.checkboxValue}
+                  checkboxValue={item.checkboxValue}
+                  title={item.title}
+                  toLabel={t('word.to')}
+                  description={item.description}
+                  sender={item.sender}
+                  receiver={item.receiver}
+                  isChecked={selectedItems[item.checkboxValue]}
+                  onCheckedChange={(checked) => handleCheckedChange(item.checkboxValue, checked)}
+                  tags={item.tags}
+                  linkTo={item.linkTo}
+                />
+              ))}
+            </InboxItems>
+          );
+        })}
+      </section>
     </main>
   );
 };


### PR DESCRIPTION
Organisere InboxItems etter gruppe (eksempelvis årstall, jf. skissene), med mulighet for å velge alle innen hver gruppe.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->