### PR TITLE
feat: add filter to inbox page

### DIFF
--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -40,4 +40,5 @@ jobs:
               - 'packages/bff/**/*'
               - 'packages/bff-frontend-poc/**/*'
               - 'packages/frontend-design-poc/**/*'
+              - 'packages/dialogporten-types-generated/**/*'
               - 'packages/storybook/**/*'

--- a/packages/dialogporten-types-generated/package.json
+++ b/packages/dialogporten-types-generated/package.json
@@ -1,11 +1,14 @@
 {
   "name": "dialogporten-types-generated",
+  "main": "src/index.ts",
   "version": "1.0.0",
   "scripts": {
-    "build": "swagger-typescript-api --path ./node_modules/dialogporten-swagger/swagger.json -o generated --modular --clean-output --module-name-first-tag"
+    "prepare": "pnpm run generate:types",
+    "build": "pnpm run generate:types",
+    "generate:types": "swagger-typescript-api --path ./node_modules/@digdir/dialogporten-swagger/swagger.verified.json -o generated --modular --clean-output --module-name-first-tag --union-enums"
   },
   "dependencies": {
-    "dialogporten-swagger": "^1.0.4",
+    "@digdir/dialogporten-swagger": "1.1.0",
     "swagger-typescript-api": "13.0.3"
   }
 }

--- a/packages/dialogporten-types-generated/src/index.ts
+++ b/packages/dialogporten-types-generated/src/index.ts
@@ -1,1 +1,4 @@
 export * from '../generated/Enduser';
+export * from '../generated/data-contracts';
+export * from '../generated/http-client';
+export * from '../generated/Serviceowner';

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -30,9 +30,7 @@ const config: Config = {
     mermaid: true,
   },
 
-	plugins: [
-		'docusaurus-tldraw-plugin',	
-	],
+  plugins: ['docusaurus-tldraw-plugin'],
 
   themes: [
     /* mermaid */

--- a/packages/frontend-design-poc/package.json
+++ b/packages/frontend-design-poc/package.json
@@ -28,7 +28,8 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^14.0.3",
     "react-query": "^3.39.3",
-    "react-router-dom": "^6.16.0"
+    "react-router-dom": "^6.16.0",
+    "dialogporten-types-generated": "workspace:*"
   },
   "devDependencies": {
     "@playwright/test": "^1.41.2",

--- a/packages/frontend-design-poc/src/api/queries.ts
+++ b/packages/frontend-design-poc/src/api/queries.ts
@@ -1,6 +1,9 @@
+import { GetDialogDtoSO } from 'dialogporten-types-generated';
+
 interface User {
   name: string;
   roles: string[];
 }
 
 export const getUser = (): Promise<User> => fetch('/user').then((resp) => resp.json());
+export const getDialogs = (): Promise<GetDialogDtoSO[]> => fetch('/dialogs').then((resp) => resp.json());

--- a/packages/frontend-design-poc/src/components/FilterBar/filterBar.module.css
+++ b/packages/frontend-design-poc/src/components/FilterBar/filterBar.module.css
@@ -1,5 +1,4 @@
 .filterBar {
-    padding: 1em;
     display: flex;
     align-items: flex-start;
     column-gap: 1em;

--- a/packages/frontend-design-poc/src/components/Header/Header.tsx
+++ b/packages/frontend-design-poc/src/components/Header/Header.tsx
@@ -1,13 +1,13 @@
 import { Search } from '@digdir/designsystemet-react';
+import { DogIcon } from '@navikt/aksel-icons';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { useWindowSize } from '../../../utils/useWindowSize';
+import { MenuBar } from '../MenuBar';
+import { MenuBarItemProps } from '../MenuBar/MenuBarItem';
 import { AltinnLogoSvg } from './AltinnLogo';
 import styles from './header.module.css';
-import { useWindowSize } from '../../../utils/useWindowSize';
-import { useTranslation } from 'react-i18next';
-import { MenuBar } from '../MenuBar';
-import { DogIcon } from '@navikt/aksel-icons';
-import { MenuBarItemProps } from '../MenuBar/MenuBarItem';
 
 type HeaderProps = {
   name: string;

--- a/packages/frontend-design-poc/src/components/InboxItem/inboxItem.module.css
+++ b/packages/frontend-design-poc/src/components/InboxItem/inboxItem.module.css
@@ -28,6 +28,7 @@
     flex-direction: column;
     padding: 0 1.0625em 1.0625em;
     border-left: 4px solid rgba(0, 0, 0, 0.10);
+    margin-left: 1rem;
 }
 
 .isUnread {

--- a/packages/frontend-design-poc/src/components/InboxItem/inboxItemDetail.module.css
+++ b/packages/frontend-design-poc/src/components/InboxItem/inboxItemDetail.module.css
@@ -1,11 +1,12 @@
 .inboxItemDetail {
     display: flex;
     flex-direction: column;
-    padding: 0 1.0625em 1.0625em;
+    padding: 0 1.0625rem 1.0625rem;
+    background: #fff;
 }
 
 .descriptionContainer {
-    padding: 0 1.0625em 1.0625em;
+    padding: 0 1.0625rem 1.0625rem;
     border-left: 4px solid rgba(0, 0, 0, 0.10);
     margin-top: 1rem;
 }
@@ -78,7 +79,7 @@
 }
 
 .tagIcon {
-    margin-right: 0.5em;
+    margin-right: 0.5rem;
     height: 20px;
     width: 20px;
     flex-shrink: 0;

--- a/packages/frontend-design-poc/src/components/InboxItem/inboxItems.module.css
+++ b/packages/frontend-design-poc/src/components/InboxItem/inboxItems.module.css
@@ -1,7 +1,8 @@
 .inboxItems {
     display: flex;
     flex-direction: column;
-    row-gap: .5em;
+    row-gap: 8px;
+    background: #fff;
     /* Reset default ul styles */
     list-style: none;
     padding-left: 0;

--- a/packages/frontend-design-poc/src/components/InboxItem/inboxItemsHeader.module.css
+++ b/packages/frontend-design-poc/src/components/InboxItem/inboxItemsHeader.module.css
@@ -3,4 +3,5 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    padding: 0 1rem;
 }

--- a/packages/frontend-design-poc/src/components/MenuBar/MenuBar.tsx
+++ b/packages/frontend-design-poc/src/components/MenuBar/MenuBar.tsx
@@ -1,10 +1,10 @@
-import { useTranslation } from 'react-i18next';
-import { useWindowSize } from '../../../utils/useWindowSize';
-import styles from './menubar.module.css';
 import cx from 'classnames';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useWindowSize } from '../../../utils/useWindowSize';
 import { Avatar } from '../Avatar/Avatar';
 import { MenuBarDropdown, MenuBarItemProps } from './MenuBarItem';
+import styles from './menubar.module.css';
 
 interface MenuBarProps {
   name: string;

--- a/packages/frontend-design-poc/src/components/PageLayout/pageLayout.module.css
+++ b/packages/frontend-design-poc/src/components/PageLayout/pageLayout.module.css
@@ -21,7 +21,6 @@
 }
 
 .pageLayout>main {
-    background: white;
     margin-right: 192px;
     grid-area: main;
     padding: 1.5rem;

--- a/packages/frontend-design-poc/src/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend-design-poc/src/components/Sidebar/Sidebar.tsx
@@ -10,9 +10,9 @@ import {
 } from '@navikt/aksel-icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useWindowSize } from '../../../utils/useWindowSize';
 import { SidebarItem } from './';
 import styles from './sidebar.module.css';
-import { useWindowSize } from '../../../utils/useWindowSize';
 
 export interface SidebarProps {
   children?: React.ReactNode;

--- a/packages/frontend-design-poc/src/mocks/dialogs.tsx
+++ b/packages/frontend-design-poc/src/mocks/dialogs.tsx
@@ -1,0 +1,489 @@
+import { GetDialogContentDtoSO, GetDialogDtoSO } from 'dialogporten-types-generated';
+import { InboxItemInput } from '../pages/Inbox/Inbox.tsx';
+
+export const dialogs: GetDialogDtoSO[] = [
+  {
+    id: '49608e01-0329-0572-aaaf-20fbb19d3b4a',
+    revision: '75c6ce94-a81a-4e49-92b3-22f994b14bfd',
+    org: 'digdir',
+    serviceResource: 'urn:altinn:resource:ttd-dialogporten-automated-tests',
+    party: 'urn:altinn:organization:identifier-no::212475912',
+    createdAt: '2024-03-21T08:55:42.5906890Z',
+    updatedAt: '2024-03-21T08:55:42.5906890Z',
+    status: 'New',
+    content: [
+      {
+        type: 'Title',
+        value: [
+          {
+            value: 'Skjema for rapportering av et eller annet',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'Summary',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'AdditionalInfo',
+        value: [
+          {
+            value:
+              'Noe tilsvarende \'body\' i dag (<a href="https://github.com/digdir/dialogporten/blob/main/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/FluentValidation/FluentValidation_LocalizationDto_Extensions.cs">enkel HTML-støtte</a>, inntil 1023 tegn). Ikke påkrevd. Vises kun i detaljvisning.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+    elements: [
+      {
+        id: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
+        type: 'super-simple-service:prefill',
+        urls: [
+          {
+            id: '39608e01-0529-0d76-9bab-6c4e361ab37d',
+            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data/9b18d9f2-d197-4e5a-9b80-bdc0872f1a53',
+            mimeType: 'application/json',
+            consumerType: 'Api',
+          },
+        ],
+      },
+      {
+        id: '39608e01-0529-0d76-9bba-00dc83eea40f',
+        displayName: [
+          {
+            value: 'Information Letter',
+            cultureCode: 'en-us',
+          },
+          {
+            value: 'Informasjonsskriv',
+            cultureCode: 'nb-no',
+          },
+        ],
+        urls: [
+          {
+            id: '39608e01-0529-0d76-9bca-dba8582098fb',
+            url: 'https://someexternalsite.com/with/a/document.pdf',
+            mimeType: 'application/pdf',
+            consumerType: 'Gui',
+          },
+          {
+            id: '39608e01-0529-0d76-9bd9-0b5da4b51c10',
+            url: 'https://someexternalsite.com/with/a/document.docx',
+            mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            consumerType: 'Gui',
+          },
+        ],
+      },
+    ],
+    guiActions: [
+      {
+        id: '39608e01-0529-0d76-9bda-19dc3598753b',
+        action: 'submit',
+        url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c',
+        isBackChannel: false,
+        isDeleteAction: false,
+        priority: 'Primary',
+        title: [
+          {
+            value: 'Gå til innsending',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+    apiActions: [
+      {
+        id: '39608e01-0429-9373-90e5-8548698fc5a0',
+        action: 'submit',
+        endpoints: [
+          {
+            id: '39608e01-0429-9373-90f4-5e49e4855264',
+            version: '20231015',
+            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data?dataType=mainform-20231015',
+            httpMethod: 'POST',
+            requestSchema:
+              'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/api/jsonschema/mainform-20231015',
+            responseSchema: 'https://docs.altinn.studio/swagger/altinn-app-v1.json#/components/schemas/DataElement',
+            deprecated: false,
+          },
+        ],
+      },
+    ],
+    activities: [
+      {
+        id: '39608e01-0429-9373-90cd-c281b4130de7',
+        createdAt: '2024-03-21T08:00:00.0000000Z',
+        type: 'Information',
+        dialogElementId: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
+        performedBy: [
+          {
+            value: 'Norwegian Digitalisation Agency ',
+            cultureCode: 'en-us',
+          },
+          {
+            value: 'Digitaliseringsdirektoratet avd. BOD',
+            cultureCode: 'nb-no',
+          },
+        ],
+        description: [
+          {
+            value: 'Form created and prefilled',
+            cultureCode: 'en-us',
+          },
+          {
+            value: 'Skjema opprettet og forhåndsutfylt',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        id: '6d26ab76-f957-4229-a4b2-20dbe80df470',
+        createdAt: '2024-03-21T08:55:52.0028870Z',
+        type: 'Seen',
+        performedBy: [
+          {
+            value: 'Local Development User',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '59608e01-0329-0572-aaaf-20fbb19d3b4a',
+    revision: '75c6ce94-a81a-4e49-92b3-22f994b14bfd',
+    org: 'digdir',
+    serviceResource: 'urn:altinn:resource:ttd-dialogporten-automated-tests',
+    party: 'urn:altinn:organization:identifier-no::212475912',
+    createdAt: '2024-03-21T08:55:42.5906890Z',
+    updatedAt: '2024-03-21T08:55:42.5906890Z',
+    status: 'New',
+    content: [
+      {
+        type: 'Title',
+        value: [
+          {
+            value: 'Skjema for rapportering av noe viktig',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'Summary',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'AdditionalInfo',
+        value: [
+          {
+            value:
+              'Noe tilsvarende \'body\' i dag (<a href="https://github.com/digdir/dialogporten/blob/main/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/FluentValidation/FluentValidation_LocalizationDto_Extensions.cs">enkel HTML-støtte</a>, inntil 1023 tegn). Ikke påkrevd. Vises kun i detaljvisning.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+    elements: [
+      {
+        id: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
+        type: 'super-simple-service:prefill',
+        urls: [
+          {
+            id: '39608e01-0529-0d76-9bab-6c4e361ab37d',
+            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data/9b18d9f2-d197-4e5a-9b80-bdc0872f1a53',
+            mimeType: 'application/json',
+            consumerType: 'Api',
+          },
+        ],
+      },
+      {
+        id: '39608e01-0529-0d76-9bba-00dc83eea40f',
+        displayName: [
+          {
+            value: 'Information Letter',
+            cultureCode: 'en-us',
+          },
+          {
+            value: 'Informasjonsskriv',
+            cultureCode: 'nb-no',
+          },
+        ],
+        urls: [
+          {
+            id: '39608e01-0529-0d76-9bca-dba8582098fb',
+            url: 'https://someexternalsite.com/with/a/document.pdf',
+            mimeType: 'application/pdf',
+            consumerType: 'Gui',
+          },
+          {
+            id: '39608e01-0529-0d76-9bd9-0b5da4b51c10',
+            url: 'https://someexternalsite.com/with/a/document.docx',
+            mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            consumerType: 'Gui',
+          },
+        ],
+      },
+    ],
+    guiActions: [
+      {
+        id: '39608e01-0529-0d76-9bda-19dc3598753b',
+        action: 'submit',
+        url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c',
+        isBackChannel: false,
+        isDeleteAction: false,
+        priority: 'Primary',
+        title: [
+          {
+            value: 'Gå til innsending',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+    apiActions: [
+      {
+        id: '39608e01-0429-9373-90e5-8548698fc5a0',
+        action: 'submit',
+        endpoints: [
+          {
+            id: '39608e01-0429-9373-90f4-5e49e4855264',
+            version: '20231015',
+            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data?dataType=mainform-20231015',
+            httpMethod: 'POST',
+            requestSchema:
+              'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/api/jsonschema/mainform-20231015',
+            responseSchema: 'https://docs.altinn.studio/swagger/altinn-app-v1.json#/components/schemas/DataElement',
+            deprecated: false,
+          },
+        ],
+      },
+    ],
+    activities: [
+      {
+        id: '39608e01-0429-9373-90cd-c281b4130de7',
+        createdAt: '2024-03-21T08:00:00.0000000Z',
+        type: 'Information',
+        dialogElementId: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
+        performedBy: [
+          {
+            value: 'Norwegian Digitalisation Agency ',
+            cultureCode: 'en-us',
+          },
+          {
+            value: 'Digitaliseringsdirektoratet avd. BOD',
+            cultureCode: 'nb-no',
+          },
+        ],
+        description: [
+          {
+            value: 'Form created and prefilled',
+            cultureCode: 'en-us',
+          },
+          {
+            value: 'Skjema opprettet og forhåndsutfylt',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        id: '6d26ab76-f957-4229-a4b2-20dbe80df470',
+        createdAt: '2024-03-21T08:55:52.0028870Z',
+        type: 'Seen',
+        performedBy: [
+          {
+            value: 'Local Development User',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '39608e01-0329-0572-aaaf-20fbb19d3b4a',
+    revision: '75c6ce94-a81a-4e49-92b3-22f994b14bfd',
+    org: 'digdir',
+    serviceResource: 'urn:altinn:resource:ttd-dialogporten-automated-tests',
+    party: 'urn:altinn:organization:identifier-no::212475912',
+    createdAt: '2023-03-21T08:55:42.5906890Z',
+    updatedAt: '2023-03-21T08:55:42.5906890Z',
+    status: 'New',
+    content: [
+      {
+        type: 'Title',
+        value: [
+          {
+            value: 'Skjema for rapportering av noe sånt som det',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'Summary',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'AdditionalInfo',
+        value: [
+          {
+            value:
+              'Noe tilsvarende \'body\' i dag (<a href="https://github.com/digdir/dialogporten/blob/main/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/FluentValidation/FluentValidation_LocalizationDto_Extensions.cs">enkel HTML-støtte</a>, inntil 1023 tegn). Ikke påkrevd. Vises kun i detaljvisning.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+    elements: [
+      {
+        id: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
+        type: 'super-simple-service:prefill',
+        urls: [
+          {
+            id: '39608e01-0529-0d76-9bab-6c4e361ab37d',
+            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data/9b18d9f2-d197-4e5a-9b80-bdc0872f1a53',
+            mimeType: 'application/json',
+            consumerType: 'Api',
+          },
+        ],
+      },
+      {
+        id: '39608e01-0529-0d76-9bba-00dc83eea40f',
+        displayName: [
+          {
+            value: 'Information Letter',
+            cultureCode: 'en-us',
+          },
+          {
+            value: 'Informasjonsskriv',
+            cultureCode: 'nb-no',
+          },
+        ],
+        urls: [
+          {
+            id: '39608e01-0529-0d76-9bca-dba8582098fb',
+            url: 'https://someexternalsite.com/with/a/document.pdf',
+            mimeType: 'application/pdf',
+            consumerType: 'Gui',
+          },
+          {
+            id: '39608e01-0529-0d76-9bd9-0b5da4b51c10',
+            url: 'https://someexternalsite.com/with/a/document.docx',
+            mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            consumerType: 'Gui',
+          },
+        ],
+      },
+    ],
+    guiActions: [
+      {
+        id: '39608e01-0529-0d76-9bda-19dc3598753b',
+        action: 'submit',
+        url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c',
+        isBackChannel: false,
+        isDeleteAction: false,
+        priority: 'Primary',
+        title: [
+          {
+            value: 'Gå til innsending',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+    apiActions: [
+      {
+        id: '39608e01-0429-9373-90e5-8548698fc5a0',
+        action: 'submit',
+        endpoints: [
+          {
+            id: '39608e01-0429-9373-90f4-5e49e4855264',
+            version: '20231015',
+            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data?dataType=mainform-20231015',
+            httpMethod: 'POST',
+            requestSchema:
+              'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/api/jsonschema/mainform-20231015',
+            responseSchema: 'https://docs.altinn.studio/swagger/altinn-app-v1.json#/components/schemas/DataElement',
+            deprecated: false,
+          },
+        ],
+      },
+    ],
+    activities: [
+      {
+        id: '39608e01-0429-9373-90cd-c281b4130de7',
+        createdAt: '2024-03-21T08:00:00.0000000Z',
+        type: 'Information',
+        dialogElementId: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
+        performedBy: [
+          {
+            value: 'Norwegian Digitalisation Agency ',
+            cultureCode: 'en-us',
+          },
+          {
+            value: 'Digitaliseringsdirektoratet avd. BOD',
+            cultureCode: 'nb-no',
+          },
+        ],
+        description: [
+          {
+            value: 'Form created and prefilled',
+            cultureCode: 'en-us',
+          },
+          {
+            value: 'Skjema opprettet og forhåndsutfylt',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        id: '6d26ab76-f957-4229-a4b2-20dbe80df470',
+        createdAt: '2024-03-21T08:55:52.0028870Z',
+        type: 'Seen',
+        performedBy: [
+          {
+            value: 'Local Development Admin',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export function mapDialogDtoToInboxItem(input: GetDialogDtoSO[]): InboxItemInput[] {
+  return input.map((item) => {
+    const titleObj = item?.content?.find((c: GetDialogContentDtoSO) => c.type === 'Title');
+    const summaryObj = item?.content?.find((c: GetDialogContentDtoSO) => c.type === 'Summary');
+    const sender = item.activities?.length
+      ? item.activities[item.activities.length - 1]?.performedBy?.[0]?.value ?? 'Unknown'
+      : 'Unknown';
+    return {
+      id: item.id ?? 'MISSING_ID', // Providing a default value for id if it's undefined
+      title: titleObj?.value?.[0]?.value || 'No Title',
+      description: summaryObj?.value?.[0]?.value ?? 'No Description',
+      sender: { label: sender },
+      receiver: { label: 'Static Receiver' },
+      tags: [],
+      linkTo: `/inbox/${item.id}`,
+      date: item.createdAt ?? '',
+      createdAt: item.createdAt ?? '',
+      status: item.status ?? 'UnknownStatus',
+    };
+  });
+}

--- a/packages/frontend-design-poc/src/mocks/handlers.ts
+++ b/packages/frontend-design-poc/src/mocks/handlers.ts
@@ -1,7 +1,11 @@
 import { http, HttpResponse } from 'msw';
+import { dialogs as mockedDialogs } from './dialogs.tsx';
 
 export const handlers = [
   http.get('/user', () => {
     return HttpResponse.json({ name: 'John Doe', scopes: [] });
+  }),
+  http.get('/dialogs', () => {
+    return HttpResponse.json(mockedDialogs);
   }),
 ];

--- a/packages/frontend-design-poc/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend-design-poc/src/pages/Inbox/Inbox.tsx
@@ -1,21 +1,17 @@
-import {
-  ArrowForwardIcon,
-  ClockDashedIcon,
-  EnvelopeOpenIcon,
-  PersonIcon,
-  PersonSuitIcon,
-  SealIcon,
-  StarIcon,
-  TrashIcon,
-} from '@navikt/aksel-icons';
+import { ArrowForwardIcon, ClockDashedIcon, EnvelopeOpenIcon, PersonIcon, TrashIcon } from '@navikt/aksel-icons';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQuery } from 'react-query';
+import { getDialogs } from '../../api/queries.ts';
 import { ActionPanel, InboxItem, InboxItemTag, InboxItems, Participant } from '../../components';
+import { type Filter, FilterBar } from '../../components/FilterBar';
+import { FilterBarField } from '../../components/FilterBar/FilterBar.tsx';
 import { InboxItemsHeader } from '../../components/InboxItem/InboxItemsHeader.tsx';
+import { mapDialogDtoToInboxItem } from '../../mocks/dialogs.tsx';
 import styles from './inbox.module.css';
 
-interface Dialog {
-  checkboxValue: string;
+export interface InboxItemInput {
+  id: string;
   title: string;
   description: string;
   sender: Participant;
@@ -23,6 +19,18 @@ interface Dialog {
   tags: InboxItemTag[];
   linkTo: string;
   date: string;
+  createdAt: string;
+  status: string;
+}
+
+function countOccurrences(array: string[]): Record<string, number> {
+  return array.reduce(
+    (acc, item) => {
+      acc[item] = (acc[item] || 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
 }
 
 export const Inbox = () => {
@@ -30,117 +38,65 @@ export const Inbox = () => {
   const [selectedItems, setSelectedItems] = useState<{
     [key: string]: boolean;
   }>({});
+
+  const { data: dialogs } = useQuery('dialogs', getDialogs);
+  const dialogData = useMemo(() => mapDialogDtoToInboxItem(dialogs || []), [dialogs]);
+  const [activeFilters, setActiveFilters] = useState<Filter[]>([]);
   const selectedItemCount = Object.values(selectedItems).filter(Boolean).length;
 
-  const data: Dialog[] = [
-    {
-      checkboxValue: 'test',
-      title: 'Viktig melding',
-      description: 'Du har mottatt en viktig melding!',
-      sender: { label: 'Viktig bedrift', icon: <PersonSuitIcon /> },
-      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
-      tags: [
-        { label: 'hello', icon: <StarIcon /> },
-        { label: 'hallaz', icon: <SealIcon /> },
-      ],
-      linkTo: '/inbox/1',
-      date: '2023-08-15',
-    },
-    {
-      checkboxValue: 'test2',
-      title: 'Har du glemt oss?',
-      description: 'Det tror jeg du har!',
-      sender: { label: 'Viktig bedrift', icon: <PersonSuitIcon /> },
-      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
-      tags: [
-        { label: 'hello', icon: <StarIcon /> },
-        { label: 'hallaz', icon: <SealIcon /> },
-      ],
-      linkTo: '/inbox/2',
-      date: '2023-09-20',
-    },
-    {
-      checkboxValue: 'test3',
-      title: 'Årsrapport klar',
-      description: 'Din årsrapport for 2023 er nå tilgjengelig.',
-      sender: { label: 'Regnskapsfirmaet AS', icon: <PersonSuitIcon /> },
-      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
-      tags: [
-        { label: 'rapport', icon: <SealIcon /> },
-        { label: 'viktig', icon: <StarIcon /> },
-      ],
-      linkTo: '/inbox/3',
-      date: '2024-01-05',
-    },
-    {
-      checkboxValue: 'test4',
-      title: 'Oppdatering av vilkår',
-      description: 'Vilkårene for bruk av vår tjeneste er oppdatert.',
-      sender: { label: 'Tjeneste AS', icon: <PersonSuitIcon /> },
-      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
-      tags: [
-        { label: 'oppdatering', icon: <EnvelopeOpenIcon /> },
-        { label: 'vilkår', icon: <SealIcon /> },
-      ],
-      linkTo: '/inbox/4',
-      date: '2024-02-14',
-    },
-    {
-      checkboxValue: 'test5',
-      title: 'Invitasjon til webinar',
-      description: 'Du er invitert til vårt eksklusive webinar om fremtidens teknologi.',
-      sender: { label: 'Teknologi AS', icon: <PersonSuitIcon /> },
-      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
-      tags: [
-        { label: 'webinar', icon: <StarIcon /> },
-        { label: 'invitasjon', icon: <EnvelopeOpenIcon /> },
-      ],
-      linkTo: '/inbox/5',
-      date: '2024-03-10',
-    },
-    {
-      checkboxValue: 'test6',
-      title: 'Påminnelse om betaling',
-      description: 'Vennligst husk å betale faktura nr. 45677 innen 15.04.2023.',
-      sender: { label: 'Fakturaservice AS', icon: <PersonSuitIcon /> },
-      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
-      tags: [
-        { label: 'påminnelse', icon: <ClockDashedIcon /> },
-        { label: 'faktura', icon: <SealIcon /> },
-      ],
-      linkTo: '/inbox/6',
-      date: '2023-03-30',
-    },
-    {
-      checkboxValue: 'test7',
-      title: 'Velkommen som ny bruker!',
-      description: 'Vi ønsker deg velkommen som ny bruker og ser frem til et godt samarbeid.',
-      sender: { label: 'Velkomstteamet', icon: <PersonSuitIcon /> },
-      receiver: { label: 'Bruker Brukerson', icon: <PersonIcon /> },
-      tags: [
-        { label: 'velkommen', icon: <StarIcon /> },
-        { label: 'ny bruker', icon: <EnvelopeOpenIcon /> },
-      ],
-      linkTo: '/inbox/7',
-      date: '2024-04-01',
-    },
-  ];
-
-  const dataGroupedByYear = useMemo(
-    () =>
-      data.reduce(
-        (acc: Record<string, Dialog[]>, item) => {
-          const year = String(new Date(item.date).getFullYear());
-          if (!acc[year]) {
-            acc[year] = [];
+  const filteredData = useMemo(() => {
+    return dialogData.filter((item) =>
+      activeFilters.every((filter) => {
+        if (Array.isArray(filter.value)) {
+          return filter.value.includes(String(item[filter.fieldName as keyof InboxItemInput]));
+        }
+        if (typeof filter.value === 'string') {
+          if (filter.fieldName === 'sender') {
+            const sender = item[filter.fieldName as keyof InboxItemInput] as Participant;
+            return filter.value === sender.label;
           }
-          acc[year].push(item);
-          return acc;
-        },
-        {} as Record<string, Dialog[]>,
-      ),
-    [data],
-  );
+          return filter.value === item[filter.fieldName as keyof InboxItemInput];
+        }
+        return true;
+      }),
+    );
+  }, [dialogData, activeFilters]);
+
+  const filterBarFields: FilterBarField[] = useMemo(() => {
+    return [
+      {
+        id: 'sender',
+        label: 'Avsender',
+        unSelectedLabel: 'Alle avsendere',
+        leftIcon: <PersonIcon />,
+        options: (() => {
+          const senders = filteredData.map((p) => p.sender.label);
+          const senderCounts = countOccurrences(senders);
+          return Array.from(new Set(senders)).map((sender) => ({
+            id: sender,
+            label: sender,
+            value: sender,
+            count: senderCounts[sender],
+            operation: 'equals',
+          }));
+        })(),
+      },
+    ];
+  }, [filteredData]);
+
+  const dataGroupedByYear = useMemo(() => {
+    return filteredData.reduce(
+      (acc: Record<string, InboxItemInput[]>, item) => {
+        const year = String(new Date(item.date).getFullYear());
+        if (!acc[year]) {
+          acc[year] = [];
+        }
+        acc[year].push(item);
+        return acc;
+      },
+      {} as Record<string, InboxItemInput[]>,
+    );
+  }, [filteredData]);
 
   const handleCheckedChange = (checkboxValue: string, checked: boolean) => {
     setSelectedItems((prev: Record<string, boolean>) => ({
@@ -151,7 +107,9 @@ export const Inbox = () => {
 
   return (
     <main>
-      <h1>{t('example.your_inbox')}</h1>
+      <div className={styles.filterBarWrapper}>
+        <FilterBar fields={filterBarFields} onFilterChange={(filters) => setActiveFilters(filters)} />
+      </div>
       {selectedItemCount > 0 && (
         <div className={styles.actionPanelWrapper}>
           <ActionPanel
@@ -179,41 +137,41 @@ export const Inbox = () => {
         </div>
       )}
       <section>
-        {Object.entries(dataGroupedByYear).map(([year, items]) => {
-          const hideSelectAll = items.every((item) => selectedItems[item.checkboxValue]);
-          return (
-            <InboxItems key={year}>
-              <InboxItemsHeader
-                hideSelectAll={hideSelectAll}
-                onSelectAll={() => {
-                  const newItems = items
-                    .map((item) => ({ key: item.checkboxValue, checked: true }))
-                    .reduce((acc, item) => ({ ...acc, [item.key]: item.checked }), {});
-                  setSelectedItems({
-                    ...selectedItems,
-                    ...newItems,
-                  });
-                }}
-                title={year}
-              />
-              {items.map((item) => (
-                <InboxItem
-                  key={item.checkboxValue}
-                  checkboxValue={item.checkboxValue}
-                  title={item.title}
-                  toLabel={t('word.to')}
-                  description={item.description}
-                  sender={item.sender}
-                  receiver={item.receiver}
-                  isChecked={selectedItems[item.checkboxValue]}
-                  onCheckedChange={(checked) => handleCheckedChange(item.checkboxValue, checked)}
-                  tags={item.tags}
-                  linkTo={item.linkTo}
+        {Object.entries(dataGroupedByYear)
+          .reverse()
+          .map(([year, items]) => {
+            const hideSelectAll = items.every((item) => selectedItems[item.id]);
+            return (
+              <InboxItems key={year}>
+                <InboxItemsHeader
+                  hideSelectAll={hideSelectAll}
+                  onSelectAll={() => {
+                    const newItems = Object.fromEntries(items.map((item) => [item.id, true]));
+                    setSelectedItems({
+                      ...selectedItems,
+                      ...newItems,
+                    });
+                  }}
+                  title={year}
                 />
-              ))}
-            </InboxItems>
-          );
-        })}
+                {items.map((item) => (
+                  <InboxItem
+                    key={item.id}
+                    checkboxValue={item.id}
+                    title={item.title}
+                    toLabel={t('word.to')}
+                    description={item.description}
+                    sender={item.sender}
+                    receiver={item.receiver}
+                    isChecked={selectedItems[item.id]}
+                    onCheckedChange={(checked) => handleCheckedChange(item.id, checked)}
+                    tags={item.tags}
+                    linkTo={item.linkTo}
+                  />
+                ))}
+              </InboxItems>
+            );
+          })}
       </section>
     </main>
   );

--- a/packages/frontend-design-poc/src/pages/Inbox/inbox.module.css
+++ b/packages/frontend-design-poc/src/pages/Inbox/inbox.module.css
@@ -4,5 +4,9 @@
     width: 100%;
 }
 .actionPanelWrapper {
-    margin: 2em 0;
+    margin: 2rem 0;
+}
+
+.filterBarWrapper {
+    margin-bottom: 1rem;
 }

--- a/packages/frontend-design-poc/utils/useWindowSize.tsx
+++ b/packages/frontend-design-poc/utils/useWindowSize.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 const mobileBreakpoint = 768;
 

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -1,5 +1,5 @@
-import '@digdir/designsystemet-theme';
 import '@digdir/designsystemet-css';
+import '@digdir/designsystemet-theme';
 import { A11yParameters } from '@storybook/addon-a11y';
 import type { Preview } from '@storybook/react';
 import { Rule, getRules } from 'axe-core';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,9 +329,9 @@ importers:
 
   packages/dialogporten-types-generated:
     dependencies:
-      dialogporten-swagger:
-        specifier: ^1.0.4
-        version: 1.0.4
+      '@digdir/dialogporten-swagger':
+        specifier: 1.1.0
+        version: 1.1.0
       swagger-typescript-api:
         specifier: 13.0.3
         version: 13.0.3
@@ -426,6 +426,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      dialogporten-types-generated:
+        specifier: workspace:*
+        version: link:../dialogporten-types-generated
       i18next:
         specifier: ^23.8.2
         version: 23.8.2
@@ -2691,6 +2694,10 @@ packages:
 
   /@digdir/designsystemet-theme@0.13.1-alpha.0:
     resolution: {integrity: sha512-NgbcDqYf/3niVq98zteoRMbDERYhetoN6WPRcPtlpwJbOyUH1bsN6kFVpaNe9iiDb7JEqxCQXpUgMKi863IiTA==}
+    dev: false
+
+  /@digdir/dialogporten-swagger@1.1.0:
+    resolution: {integrity: sha512-Uo45Rv6XzG7AFHQlR/xZFdNx+kRf2G3Dd+hu6cnuVVQ36Qi8KGVNBh1EBadwg6wV+tj1PLVoh0oWgdCqDLo2LA==}
     dev: false
 
   /@discoveryjs/json-ext@0.5.7:
@@ -11242,10 +11249,6 @@ packages:
     resolution: {integrity: sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==}
     dependencies:
       semver: 7.5.4
-    dev: false
-
-  /dialogporten-swagger@1.0.4:
-    resolution: {integrity: sha512-+vkGl/K8cIHvzCBSiJh5HobQccSrCATtYiRBbj/Mn/XNRGOTh/UpugFy8zSwo9omRkvqmoNH3rMFBsckEZB3Dg==}
     dev: false
 
   /didyoumean@1.2.2:

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
+    "build:dialogporten-types-generated": {
+      "dependsOn": ["^build"],
+      "outputs": ["generated/**"],
+      "cache": false
+    },
     "build": {
+      "dependsOn": ["build:dialogporten-types-generated"],
       "cache": false
     },
     "test": {


### PR DESCRIPTION
Tar i bruk filterBar-komponent i visning over "mine dialoger" (`inbox`):

- Oppdatert `npm`-pakke for  `types-generated` og eksponere typene
- Har lagt til noe eksempeldata som mockes nå ved `msw` som hentes via `react-query`
- Bruker filterBar-komponenten, foreløpig kun filter er "avsender", med realistisk-ish data.
- Strammen opp visningen visuelt

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)

![image](https://github.com/digdir/dialogporten-frontend/assets/3768832/6061f7cf-2bf1-43eb-9e77-746028c53011)
