### PR TITLE
feature: improve login flow for app (#436)

### DIFF
--- a/packages/bff/src/userApi.ts
+++ b/packages/bff/src/userApi.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
-import fp, { PluginMetadata } from 'fastify-plugin';
+import fp from 'fastify-plugin';
 import { ProfileRepository } from './db';
 import { Profile } from './entities/Profile';
 import { validateRequest } from './oidc';
@@ -42,22 +42,24 @@ const plugin: FastifyPluginAsync = async (fastify, options) => {
     }
   });
 
-  fastify.get('/api/token', async (request: FastifyRequest, reply: FastifyReply) => {
+  fastify.get('/api/isAuthenticated', async (request: FastifyRequest, reply: FastifyReply) => {
     try {
       const validToken = await validateRequest(request);
       if (validToken) {
         const {
           idToken: { sub, locale },
         } = validToken;
-        reply.send({
-          sub,
-          locale,
-        });
+
+        if (sub) {
+          reply.send({
+            isAuthenticated: true,
+          });
+        }
       } else {
         reply.status(401).send({ error: 'Unauthorized' });
       }
     } catch (e) {
-      console.error('Error fetching token endpoint:', e);
+      console.error('Error fetching isAuthenticated endpoint:', e);
       reply.status(500).send({ error: 'Internal Server Error' });
     }
   });

--- a/packages/frontend-design-poc/src/api/queries.ts
+++ b/packages/frontend-design-poc/src/api/queries.ts
@@ -1,9 +1,3 @@
 import { GetDialogDtoSO } from 'dialogporten-types-generated';
 
-interface User {
-  name: string;
-  roles: string[];
-}
-
-export const getUser = (): Promise<User> => fetch('/user').then((resp) => resp.json());
 export const getDialogs = (): Promise<GetDialogDtoSO[]> => fetch('/dialogs').then((resp) => resp.json());

--- a/packages/frontend-design-poc/src/auth/api.ts
+++ b/packages/frontend-design-poc/src/auth/api.ts
@@ -1,0 +1,11 @@
+export const getIsAuthenticated = async (): Promise<boolean> => {
+  try {
+    const response = await fetch('/api/isAuthenticated', {
+      credentials: 'include',
+      cache: 'no-store',
+    });
+    return response.status === 200;
+  } catch (error) {
+    return false;
+  }
+};

--- a/packages/frontend-design-poc/src/auth/index.ts
+++ b/packages/frontend-design-poc/src/auth/index.ts
@@ -1,0 +1,3 @@
+export * from './api.ts';
+export * from './url.ts';
+export * from './useAuthenticated.ts';

--- a/packages/frontend-design-poc/src/auth/url.ts
+++ b/packages/frontend-design-poc/src/auth/url.ts
@@ -1,0 +1,28 @@
+const LOGIN_REDIRECT_STORAGE_KEY = 'arbeidsflate::auth::login_Redirect';
+const LOGIN_REDIRECT_QUERY_KEY = 'loggedIn';
+
+export const sanitizeURL = (url: string) => {
+  const urlObj = new URL(url);
+  urlObj.searchParams.delete(LOGIN_REDIRECT_QUERY_KEY);
+  return urlObj.toString();
+};
+
+export const saveURL = (url: string) => {
+  localStorage.setItem(LOGIN_REDIRECT_STORAGE_KEY, sanitizeURL(url));
+};
+
+export const isRedirectURL = (url: string): boolean => {
+  return url.includes(LOGIN_REDIRECT_QUERY_KEY);
+};
+
+export const removeStoredURL = () => {
+  localStorage.removeItem(LOGIN_REDIRECT_STORAGE_KEY);
+};
+
+export const getStoredURL = (): string | null => {
+  const url = localStorage.getItem(LOGIN_REDIRECT_STORAGE_KEY);
+  if (url) {
+    return sanitizeURL(url);
+  }
+  return null;
+};

--- a/packages/frontend-design-poc/src/auth/useAuthenticated.ts
+++ b/packages/frontend-design-poc/src/auth/useAuthenticated.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { getIsAuthenticated } from './api.ts';
+import { getStoredURL, isRedirectURL, removeStoredURL, saveURL } from './url.ts';
+
+export const useAuthenticated = () => {
+  const { data: isAuthenticated, isSuccess: isAuthenticatedSuccess } = useQuery('isAuthenticated', getIsAuthenticated);
+
+  useEffect(() => {
+    const currentHref = window.location.href;
+    if (!isAuthenticated && isAuthenticatedSuccess) {
+      // user not logged in successfully
+      saveURL(currentHref);
+      (window as Window).location = `/api/login`;
+    } else if (isAuthenticatedSuccess && isAuthenticated) {
+      // already has a valid session or just logged in
+      if (isRedirectURL(currentHref)) {
+        const storedURL = getStoredURL();
+        if (storedURL) {
+          removeStoredURL();
+          (window as Window).location = storedURL;
+        }
+      }
+    }
+  }, [isAuthenticated, isAuthenticatedSuccess]);
+
+  return { isAuthenticated, isAuthenticatedSuccess };
+};

--- a/packages/frontend-design-poc/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend-design-poc/src/components/PageLayout/PageLayout.tsx
@@ -1,28 +1,21 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { Footer, Header, Sidebar } from '..';
-import styles from './pageLayout.module.css';
+import { useAuthenticated } from '../../auth/useAuthenticated.ts';
 import { FeatureFlagKeys, useFeatureFlag } from '../../featureFlags';
+import styles from './pageLayout.module.css';
 
 export const PageLayout: React.FC = () => {
   const [companyName, setCompanyName] = React.useState<string>('Aker Solutions AS');
   const isCompany = !!companyName;
   const isTestFeatureToggleEnabled = useFeatureFlag<boolean>(FeatureFlagKeys.TestFeatureToggleEnabled);
+  useAuthenticated();
 
   return (
     <div className={isCompany ? `isCompany` : ''}>
       <p>isTestFeatureToggleEnabled: {JSON.stringify(isTestFeatureToggleEnabled)}</p>
       <button type="button" onClick={() => setCompanyName(companyName !== '' ? '' : 'Aker Solutions AS')}>
         User/Company Switch
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          (window as Window).location = `/api/login`;
-          // TODO: Store current URL (will be returned to this url in PageLayout upon mount with redirected=true)
-        }}
-      >
-        Login
       </button>
       <button
         type="button"

--- a/packages/frontend-design-poc/src/main.tsx
+++ b/packages/frontend-design-poc/src/main.tsx
@@ -12,8 +12,8 @@ import { FeatureFlagProvider, featureFlags } from './featureFlags';
 
 async function enableMocking() {
   if (import.meta.env.MODE === 'development') {
-    //    const { worker } = await import('./mocks/browser');
-    //    return worker.start();
+    const { worker } = await import('./mocks/browser');
+    return worker.start();
   }
 }
 


### PR DESCRIPTION
Endrer login-flyten til å kalle på endepunkt `isAuthenticated` for å vurdere om login er nødvendig. 
Den sparer på URL og bruker redirectes tilbake tilbake til forlatt klientURL etter å ha autentisert seg mot idporten.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->