### PR TITLE
fix(azure): set supported azure Redis version

### DIFF
--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -2,7 +2,7 @@ using './main.bicep'
 
 param environment = 'test'
 param location = 'norwayeast'
-param redisVersion = '7.2'
+param redisVersion = '6.0'
 
 param keyVaultSourceKeys = json(readEnvironmentVariable('KEY_VAULT_SOURCE_KEYS'))
 

--- a/compose.yml
+++ b/compose.yml
@@ -36,7 +36,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   redis:
-    image: redis:7.2-alpine
+    image: redis:6.0-alpine
     restart: always
     ports:
       - 6379:6379


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->
- Azure Cache for Redis only supports 4.0 and 6.0. Setting version to 6.0 for both local development and Azure https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->