### PR TITLE
poc: example proxying request to dialogporten

### DIFF
--- a/.azure/applications/bff/main.bicep
+++ b/.azure/applications/bff/main.bicep
@@ -112,7 +112,7 @@ var containerAppEnvVars = [
   }
   {
     name: 'SCOPE'
-    value: 'digdir:dialogporten.noconsent openid'
+    value: 'digdir:dialogporten openid'
   }
   {
     name: 'SESSION_SECRET'

--- a/compose.yml
+++ b/compose.yml
@@ -145,7 +145,7 @@ services:
           PORT: 3000
           DEV_ENV: dev
           REDIRECT_URI: http://localhost:3000/auth/cb
-          SCOPE: digdir:dialogporten.noconsent openid
+          SCOPE: digdir:dialogporten openid
           AUTH_URL: https://login.test.idporten.no/authorize
           ISSUER_URL: https://test.idporten.no/.well-known/openid-configuration
           TOKEN_ENDPOINT: https://test.idporten.no/token

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -26,6 +26,7 @@
     "@fastify/cookie": "^9.3.1",
     "@fastify/cors": "^9.0.1",
     "@fastify/formbody": "^7.4.0",
+    "@fastify/http-proxy": "^9.5.0",
     "@fastify/oauth2": "^7.8.0",
     "@fastify/session": "^10.7.0",
     "applicationinsights": "^2.9.0",

--- a/packages/bff/src/auth/oidc.ts
+++ b/packages/bff/src/auth/oidc.ts
@@ -35,6 +35,7 @@ declare module 'fastify' {
     scope: string;
     token_type: string;
     expires_in: number;
+    id_token?: string;
   }
 
   interface Session {
@@ -88,7 +89,7 @@ const plugin: FastifyPluginAsync<CustomOICDPluginOptions> = async (fastify, opti
 
   fastify.register<OAuthPluginOptions>(oauthPlugin as unknown as FastifyPluginCallback<OAuthPluginOptions>, {
     name: 'idporten',
-    scope: ['digdir:dialogporten.noconsent', 'openid'],
+    scope: ['digdir:dialogporten', 'openid'],
     credentials: {
       client: {
         id: client_id,

--- a/packages/bff/src/auth/verifyToken.ts
+++ b/packages/bff/src/auth/verifyToken.ts
@@ -34,6 +34,7 @@ export async function getIsTokenValid(request: FastifyRequest): Promise<boolean>
         {
           grant_type: 'refresh_token',
           refresh_token: token.refresh_token,
+          scope: 'digdir:dialogporten openid',
         },
         {
           headers: {
@@ -48,12 +49,15 @@ export async function getIsTokenValid(request: FastifyRequest): Promise<boolean>
       if (updatedToken) {
         const refreshTokenExpiresAt = new Date(Date.now() + updatedToken.refresh_token_expires_in * 1000).toISOString();
         const accessTokenExpiresAt = new Date(Date.now() + updatedToken.expires_in * 1000).toISOString();
+
+        /* We need to make sure id_token is included or else it will expire and log out will not work */
         const updatedSessionStorageToken = {
           ...token,
           access_token: updatedToken,
           refresh_token_expires_at: refreshTokenExpiresAt,
           refresh_token: updatedToken.refresh_token,
           access_token_expires_at: accessTokenExpiresAt,
+          idToken: updatedToken?.id_token || token.id_token,
         };
 
         request.session.set('token', updatedSessionStorageToken);

--- a/packages/frontend-design-poc/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend-design-poc/src/components/PageLayout/PageLayout.tsx
@@ -41,6 +41,27 @@ export const PageLayout: React.FC = () => {
       <button
         type="button"
         onClick={() => {
+          fetch('api/proxy/dialogporten/api/v1/enduser/dialogs/14f18e01-7ed5-0272-a810-a5683df6c64d', {
+            method: 'GET',
+            credentials: 'include',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          })
+            .then((response) => response.json())
+            .then((d) => {
+              console.log(d);
+            })
+            .catch((error) => {
+              console.error('Error:', error);
+            });
+        }}
+      >
+        Test proxy
+      </button>
+      <button
+        type="button"
+        onClick={() => {
           (window as Window).location = `/api/logout`;
         }}
       >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@fastify/formbody':
         specifier: ^7.4.0
         version: 7.4.0
+      '@fastify/http-proxy':
+        specifier: ^9.5.0
+        version: 9.5.0
       '@fastify/oauth2':
         specifier: ^7.8.0
         version: 7.8.0
@@ -3590,6 +3593,11 @@ packages:
       fast-uri: 2.3.0
     dev: false
 
+  /@fastify/busboy@2.1.1:
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+    dev: false
+
   /@fastify/cookie@9.3.1:
     resolution: {integrity: sha512-h1NAEhB266+ZbZ0e9qUE6NnNR07i7DnNXWG9VbbZ8uC6O/hxHpl+Zoe5sw1yfdZ2U6XhToUGDnzQtWJdCaPwfg==}
     dependencies:
@@ -3621,6 +3629,18 @@ packages:
       fastify-plugin: 4.5.1
     dev: false
 
+  /@fastify/http-proxy@9.5.0:
+    resolution: {integrity: sha512-1iqIdV10d5k9YtfHq9ylX5zt1NiM50fG+rIX40qt00R694sqWso3ukyTFZVk33SDoSiBW8roB7n11RUVUoN+Ag==}
+    dependencies:
+      '@fastify/reply-from': 9.7.0
+      fast-querystring: 1.1.2
+      fastify-plugin: 4.5.1
+      ws: 8.16.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /@fastify/merge-json-schemas@0.1.1:
     resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
     dependencies:
@@ -3635,6 +3655,19 @@ packages:
       simple-oauth2: 5.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@fastify/reply-from@9.7.0:
+    resolution: {integrity: sha512-/F1QBl3FGlTqStjmiuoLRDchVxP967TZh6FZPwQteWhdLsDec8mqSACE+cRzw6qHUj3v9hfdd7JNgmb++fyFhQ==}
+    dependencies:
+      '@fastify/error': 3.4.1
+      end-of-stream: 1.4.4
+      fast-content-type-parse: 1.1.0
+      fast-querystring: 1.1.2
+      fastify-plugin: 4.5.1
+      pump: 3.0.0
+      tiny-lru: 11.2.6
+      undici: 5.28.4
     dev: false
 
   /@fastify/session@10.7.0:
@@ -16297,7 +16330,6 @@ packages:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
-    dev: true
 
   /pumpify@1.5.1:
     resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
@@ -18365,6 +18397,11 @@ packages:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
     dev: true
 
+  /tiny-lru@11.2.6:
+    resolution: {integrity: sha512-0PU3c9PjMnltZaFo2sGYv/nnJsMjG0Cxx8X6FXHPPGjFyoo1SJDxvUXW1207rdiSxYizf31roo+GrkIByQeZoA==}
+    engines: {node: '>=12'}
+    dev: false
+
   /tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
     dev: false
@@ -18831,6 +18868,13 @@ packages:
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
+
+  /undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
+    dependencies:
+      '@fastify/busboy': 2.1.1
+    dev: false
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}


### PR DESCRIPTION
Virkende PoC på å hente data via BFF fra Dialogporten i frontend. Bruker fastify-proxy for å reroute trafikk via Bff.
Validerer fortsatt session token og følger ellers normal flyt. Headers omskrives til å tilfredsstille kravene til backend.

Oppskrift:

1. Logg inn med 14886498226
2. trykk på "Test proxy"-knapp over header i klient.
3. Sjekk respons / console.log for dialog tilknyttet bruker

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->