### PR TITLE
fix: fixes broken stories in storybook that depends on react-query

### DIFF
--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -6,6 +6,7 @@ import { Rule, getRules } from 'axe-core';
 import 'frontend/src/globalColors.css';
 import i18n from 'i18next';
 import { I18nextProvider } from 'react-i18next';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { nbResources } from '../../frontend';
 import customTheme from './customTheme';
 
@@ -33,10 +34,13 @@ const preview: Preview = {
   },
   decorators: [
     (Story) => {
+      const client = new QueryClient();
       return (
-        <I18nextProvider i18n={i18n}>
-          <Story />
-        </I18nextProvider>
+        <QueryClientProvider client={client}>
+          <I18nextProvider i18n={i18n}>
+            <Story />
+          </I18nextProvider>
+        </QueryClientProvider>
       );
     },
   ],

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -22,6 +22,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^14.0.3",
+    "react-query": "^3.39.3",
     "react-router-dom": "^6.16.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,9 @@ importers:
       react-i18next:
         specifier: ^14.0.3
         version: 14.0.3(i18next@23.8.2)(react-dom@18.2.0)(react@18.2.0)
+      react-query:
+        specifier: ^3.39.3
+        version: 3.39.3(react-dom@18.2.0)(react@18.2.0)
       react-router-dom:
         specifier: ^6.16.0
         version: 6.21.3(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
Legger til `react-query` ti story wrapper for `stories` i `Storybook` slik at komponenter som krever `react-query` ikke krasjer.


## Hva er endret? 
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->