### PR TITLE
Feature/global snackbar component

### DIFF
--- a/packages/frontend/src/components/FilterBar/FilterBar.tsx
+++ b/packages/frontend/src/components/FilterBar/FilterBar.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSearchString } from '..';
+import { SavedSearch, getSearchHistory } from '../../pages/SavedSearches';
+import { useSnackbar } from '../Snackbar/useSnackbar.ts';
 import { AddFilterButton } from './AddFilterButton';
 import { FilterButton } from './FilterButton';
-import styles from './filterBar.module.css';
 import { SaveSearchButton } from './SaveSearchButton';
-import { SavedSearch, getSearchHistory } from '../../pages/SavedSearches';
-import { useSearchString } from '..';
+import styles from './filterBar.module.css';
 
 export type FieldOptionOperation = 'equals' | 'includes';
 
@@ -92,9 +94,11 @@ type ListOpenTarget = 'none' | string | 'add_filter';
  * ```
  */
 export const FilterBar = ({ onFilterChange, fields, initialFilters = [] }: FilterBarProps) => {
+  const { t } = useTranslation();
   const [activeFilters, setActiveFilters] = useState<Filter[]>(initialFilters);
   const [listOpenTarget, setListOpenTarget] = useState<ListOpenTarget>('none');
   const { searchString, queryClient } = useSearchString(); // This search string needs to be sent to the backend
+  const { openSnackbar } = useSnackbar();
 
   const handleOnRemove = useCallback(
     (fieldName: string) => {
@@ -149,7 +153,12 @@ export const FilterBar = ({ onFilterChange, fields, initialFilters = [] }: Filte
     };
     searchHistory.push(newSearch);
     localStorage.setItem('searchHistory', JSON.stringify(searchHistory));
-    queryClient.invalidateQueries('savedSearches'); // Step 3: Invalidate the 'savedSearches' query
+    openSnackbar({
+      message: t('savedSearches.saved_success'),
+      variant: 'success',
+    });
+
+    void queryClient.invalidateQueries('savedSearches'); // Step 3: Invalidate the 'savedSearches' query
   };
 
   return (

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
+import { useQueryClient } from 'react-query';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Footer, Header, Sidebar } from '..';
 import { useAuthenticated } from '../../auth';
 import { FeatureFlagKeys, useFeatureFlag } from '../../featureFlags';
-import styles from './pageLayout.module.css';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/Inbox';
-import { useQueryClient } from 'react-query';
+import { Snackbar } from '../Snackbar/Snackbar.tsx';
+import styles from './pageLayout.module.css';
 
 export const useUpdateOnLocationChange = (fn: () => void) => {
   const location = useLocation();
@@ -84,6 +85,7 @@ export const PageLayout: React.FC = () => {
         <Outlet />
         <Footer />
       </div>
+      <Snackbar />
     </div>
   );
 };

--- a/packages/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar/Sidebar.tsx
@@ -11,9 +11,9 @@ import {
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useWindowSize } from '../../../utils/useWindowSize';
+import { useSavedSearches } from '../../pages/SavedSearches';
 import { SidebarItem } from './';
 import styles from './sidebar.module.css';
-import { useSavedSearches } from '../../pages/SavedSearches';
 
 export interface SidebarProps {
   children?: React.ReactNode;
@@ -26,7 +26,11 @@ export const Sidebar: React.FC<SidebarProps> = ({ children, isCompany }) => {
   const { t } = useTranslation();
   const { data: savedSearches } = useSavedSearches();
   const { isMobile } = useWindowSize();
-  if (isMobile) return <></>;
+
+  if (isMobile) {
+    return null;
+  }
+
   return (
     <aside className={styles.sidebar}>
       {children || (

--- a/packages/frontend/src/components/Snackbar/Snackbar.tsx
+++ b/packages/frontend/src/components/Snackbar/Snackbar.tsx
@@ -1,0 +1,62 @@
+import { BellIcon, XMarkIcon } from '@navikt/aksel-icons';
+import cx from 'classnames';
+import styles from './snackbar.module.css';
+import { SnackbarStoreRecord, useSnackbar } from './useSnackbar';
+
+/**
+ * Represents an individual snackbar message item.
+ * @param {Object} props - Component props.
+ * @param {SnackbarStoreRecord} props.item - The snackbar message item.
+ * @param {Function} props.closeSnackbarItem - Function to close the snackbar message item.
+ * @param {number} props.index - Index of the snackbar message item.
+ * @returns {JSX.Element} The JSX element representing the snackbar message item.
+ */
+const SnackbarItem = ({
+  item,
+  closeSnackbarItem,
+  index,
+}: {
+  item: SnackbarStoreRecord;
+  closeSnackbarItem: (id: string) => void;
+  index: number;
+}): JSX.Element => {
+  return (
+    <div
+      className={cx(styles.snackbarItem, styles.bottomLeft, styles[item.variant])}
+      key={item.id}
+      role="status"
+      aria-live="polite"
+      style={{ marginBottom: `${70 * index}px` }}
+    >
+      <div className={styles.snackbarItemContent}>
+        <span className={styles.leftIcon} onClick={() => closeSnackbarItem(item.id)}>
+          <BellIcon />
+        </span>
+        <span className={styles.message}>{item.message}</span>
+        {item.dismissable && (
+          <span className={styles.closeIcon} onClick={() => closeSnackbarItem(item.id)}>
+            <XMarkIcon />
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Snackbar component. cf.`useSnackbar` for more info.
+ * @returns {JSX.Element|null} The JSX element representing the snackbar or null if no messages are present.
+ */
+export const Snackbar = (): JSX.Element | null => {
+  const { isOpen, storedMessages, closeSnackbarItem } = useSnackbar();
+  if (isOpen) {
+    return (
+      <div className={styles.snackbar}>
+        {storedMessages.map((item, index) => (
+          <SnackbarItem key={item.id} item={item} closeSnackbarItem={closeSnackbarItem} index={index} />
+        ))}
+      </div>
+    );
+  }
+  return null;
+};

--- a/packages/frontend/src/components/Snackbar/snackbar.module.css
+++ b/packages/frontend/src/components/Snackbar/snackbar.module.css
@@ -1,0 +1,78 @@
+@keyframes animateFromBottomLeft {
+    0% {
+        transform: scale(0.7);
+        bottom: -5px;
+    }
+    100% {
+        transform: scale(1);
+        bottom: 10px;
+    }
+}
+
+
+.snackbar {
+    display: flex;
+    flex-direction: column-reverse;
+    row-gap: 0.5rem;
+}
+
+.snackbarItem {
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.10), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    color: #fff;
+    padding: 0.625rem;
+    border-radius: 0.5rem;
+    display: flex;
+    align-items: center;
+    position: absolute;
+    bottom: 10px;
+    @media (max-width: 600px) {
+        width: 100%;
+    }
+}
+
+.bottomLeft {
+    animation: animateFromBottomLeft 230ms cubic-bezier(.21,1.02,.73,1);
+    animation-iteration-count: 1;
+}
+
+.snackbarItemContent {
+    width: 100%;
+    padding: 0.5rem;
+    display: flex;
+    align-items: center;
+}
+
+.message {
+    font-size: 1rem;
+    width: 100%;
+    font-weight: 400;
+    line-height: 1.25;
+}
+
+.leftIcon {
+    height: 1.5rem;
+    width: 1.5rem;
+    font-size: 1.5rem;
+    margin-right: 1rem;
+}
+
+.closeIcon {
+    cursor: pointer;
+    height: 1.5rem;
+    width: 1.5rem;
+    margin-left: 1rem;
+    font-size: 1.5rem;
+}
+
+.success {
+    background: var(--Person-Primary, #084826);
+}
+
+.error {
+    background: var(--Action-Danger, #861C2C);
+}
+
+.info {
+    background: #fff;
+    color: #000;
+}

--- a/packages/frontend/src/components/Snackbar/useSnackbar.spec.ts
+++ b/packages/frontend/src/components/Snackbar/useSnackbar.spec.ts
@@ -1,0 +1,91 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient } from "react-query";
+import { SnackbarDuration, useSnackbar } from "./useSnackbar";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCustomWrapper } from "../../../utils/test-utils.tsx";
+
+const queryClient = new QueryClient();
+const wrapper = createCustomWrapper(queryClient);
+
+/* work-around for https://github.com/vitest-dev/vitest/issues/3117 */
+(globalThis as unknown as any).jest = vi;
+
+describe('useSnackbar', () => {
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it('useSnackbar hook returns correct initial state', async () => {
+    const { result } = renderHook(() => useSnackbar(), { wrapper });
+
+    expect(result.current.isOpen).toEqual(false);
+    expect(result.current.storedMessages).toEqual([]);
+  });
+
+  it('useSnackbar hook updates state when opening snackbar', async () => {
+    const { result } = renderHook(() => useSnackbar(), { wrapper });
+
+    await waitFor( async() => {
+      result.current.openSnackbar({ message: 'Test Message', variant: 'info' });
+    });
+
+    await waitFor(() => expect(result.current.isOpen).equals(true));
+    expect(result.current.storedMessages.length).toBe(1);
+  });
+
+  it('useSnackbar hook closes snackbar correctly', async () => {
+    const { result } = renderHook(() => useSnackbar(), { wrapper });
+
+    const id = await waitFor(async () => {
+      return result.current.openSnackbar({ message: 'hello', variant: 'success' });
+    });
+
+    await waitFor(() => result.current.closeSnackbarItem(id));
+    await waitFor(() => expect(result.current.isOpen).equals(false));
+    await waitFor(() => expect(result.current.storedMessages.length).equals(0));
+  });
+
+  it('useSnackbar hook dismisses all snackbar messages', async () => {
+    const { result } = renderHook(() => useSnackbar(), { wrapper });
+
+    await waitFor(async () => {
+      result.current.openSnackbar({ message: 'Test Message 1', variant: 'info' });
+      result.current.openSnackbar({ message: 'Test Message 2', variant: 'success' });
+    });
+
+    expect(result.current.isOpen).equals(true);
+    expect(result.current.storedMessages.length).equals(2);
+
+    await waitFor(async () => {
+      result.current.dismissSnackbar();
+    });
+
+    expect(result.current.isOpen).toEqual(false);
+    expect(result.current.storedMessages.length).toBe(0);
+  });
+
+  it('useSnackbar hook closes snackbar automatically after duration', async () => {
+    vi.useFakeTimers();
+
+    const { result } = renderHook(() => useSnackbar(), { wrapper });
+
+    await waitFor(async () => {
+      result.current.openSnackbar({ message: 'Test Message', variant: 'info', duration: SnackbarDuration.normal });
+    });
+
+    expect(result.current.isOpen).equals(true);
+
+    vi.advanceTimersByTime(SnackbarDuration.normal);
+
+    await waitFor(async() => expect(result.current.isOpen).equals(false));
+    await waitFor(async() => expect(result.current.storedMessages.length).equals(0));
+
+    vi.useRealTimers();
+  });
+})
+
+
+
+
+
+

--- a/packages/frontend/src/components/Snackbar/useSnackbar.ts
+++ b/packages/frontend/src/components/Snackbar/useSnackbar.ts
@@ -1,0 +1,119 @@
+import { useQuery, useQueryClient } from "react-query";
+import { useCallback, useEffect, useRef } from 'react';
+
+export enum SnackbarDuration {
+  infinite= 0,
+  short= 1000,
+  normal= 3000,
+  long= 5000,
+}
+
+export type SnackbarMessageVariant =
+  | "success"
+  | "error"
+  | "info"
+
+export interface SnackbarStoreRecord {
+  id: string;
+  message: string;
+  variant: SnackbarMessageVariant;
+  duration: number;
+  dismissable: boolean;
+}
+
+interface SnackbarInput {
+  message: string;
+  variant: SnackbarMessageVariant;
+  duration?: SnackbarDuration | number;
+  dismissable?: boolean;
+}
+
+interface SnackbarOutput extends SnackbarConfig {
+  openSnackbar: (input: SnackbarInput) => string;
+  closeSnackbarItem: (id: string) => void;
+  dismissSnackbar: () => void;
+}
+
+interface SnackbarConfig {
+  isOpen: boolean;
+  storedMessages: SnackbarStoreRecord[];
+}
+
+
+/**
+ * Custom hook for managing snackbar messages.
+ * @returns SnackbarOutput object containing functions and state related to snackbar.
+ */
+export function useSnackbar(): SnackbarOutput {
+  const queryClient = useQueryClient();
+  const closingTime = useRef<NodeJS.Timeout | null>(null);
+  const queryKey = 'snackbarConfig';
+  const defaultDuration = SnackbarDuration.normal;
+
+  const initialData = {
+    isOpen: false,
+    storedMessages: []
+  }
+
+  const { data } = useQuery<SnackbarConfig>(
+    [queryKey],
+    () => (initialData),
+    {
+      enabled: false,
+      staleTime: Infinity,
+    },
+  );
+
+  const dismissSnackbar = () => {
+    void queryClient.setQueryData<SnackbarConfig>([queryKey], () => (initialData));
+    if (closingTime?.current) {
+        clearTimeout(closingTime.current);
+    }
+  };
+
+  const openSnackbar = ({message, variant, dismissable, duration}: SnackbarInput): string => {
+    const id = btoa(String(Math.random())).substring(0,12);
+    queryClient.setQueryData<SnackbarConfig>([queryKey], (oldData) => {
+      return {
+        isOpen: true,
+        storedMessages: [...oldData?.storedMessages ?? [], { id, variant, message, duration: duration ?? defaultDuration, dismissable: dismissable ?? true }]
+      }
+    });
+    return id;
+  };
+
+  const closeSnackbarItem = useCallback((id: string) => {
+    queryClient.setQueryData<SnackbarConfig>([queryKey], (oldData) => {
+      const updatedStoredMessages = (oldData?.storedMessages ?? []).filter((item) => item.id !== id);
+      const isOpen = updatedStoredMessages.length > 0;
+      return {
+        isOpen,
+        storedMessages: updatedStoredMessages
+      }
+    })}, [queryClient]);
+
+  useEffect(() => {
+    const storedMessageItem = data?.storedMessages?.filter((item) => item.duration > 0)[0];
+    if (typeof storedMessageItem !== 'undefined') {
+      closingTime.current = setTimeout(() => {
+        closeSnackbarItem(storedMessageItem?.id)
+      }, storedMessageItem.duration);
+    }
+
+    return () => {
+      if (closingTime?.current) {
+        clearTimeout(closingTime.current);
+      }
+    }
+
+  }, [data?.storedMessages, closeSnackbarItem]);
+
+
+  return {
+    isOpen: data?.isOpen ?? false,
+    storedMessages: data?.storedMessages ?? [],
+    closeSnackbarItem,
+    dismissSnackbar,
+    openSnackbar,
+  };
+}

--- a/packages/frontend/src/globalColors.css
+++ b/packages/frontend/src/globalColors.css
@@ -5,6 +5,8 @@
   --button-color: #084826;
   --avatar-color: #111D46;
   --Action-Important: #E02E49;
+  --Action-Danger: #861C2C;
+  --Person-Primary: #084826;
   --Saved-Searches-Background: rgba(75, 173, 247, 0.25);
 }
 

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -16,6 +16,7 @@
   "sidebar.deleted": "Slettet",
   "sidebar.saved_searches": "Lagrede søk",
   "savedSearches.title": "{count, plural, =0 {Ingen lagrede søk} one {# lagret søk} other {# lagrede søk}}",
+  "savedSearches.saved_success": "Søk lagret!",
   "savedSearches.lastUpdated": "Sist oppdatert: ",
   "sidebar.settings": "Innstillinger",
   "filter_bar.add_filter": "Legg til",

--- a/packages/frontend/utils/test-utils.tsx
+++ b/packages/frontend/utils/test-utils.tsx
@@ -3,23 +3,28 @@ import { ReactElement } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
 
-import '../src/i18n/config.ts';
 import { FeatureFlagProvider, featureFlags } from '../src/featureFlags';
+import '../src/i18n/config.ts';
 
 interface IExtendedRenderOptions extends RenderOptions {
   initialEntries?: string[];
 }
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
-});
+export const createCustomWrapper = (
+  ownQueryClient?: QueryClient,
+  options?: Omit<IExtendedRenderOptions, 'wrapper'>,
+) => {
+  const queryClient =
+    ownQueryClient ||
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
 
-export const customRender = (ui: ReactElement, options?: Omit<IExtendedRenderOptions, 'wrapper'>) => {
-  const Wrapper = ({ children }: { children: React.ReactNode }) => {
+  return ({ children }: { children: React.ReactNode }) => {
     return (
       <QueryClientProvider client={queryClient}>
         <FeatureFlagProvider flags={featureFlags}>
@@ -28,6 +33,10 @@ export const customRender = (ui: ReactElement, options?: Omit<IExtendedRenderOpt
       </QueryClientProvider>
     );
   };
+};
+
+export const customRender = (ui: ReactElement, options?: Omit<IExtendedRenderOptions, 'wrapper'>) => {
+  const Wrapper = createCustomWrapper(undefined, options);
 
   return render(ui, { wrapper: Wrapper, ...options });
 };

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   test: {
     exclude: ['node_modules', 'tests'], // tests for Playwright
     environment: 'jsdom',
+    sequence: {
+      setupFiles: 'list',
+    },
     globals: true,
     css: {
       modules: {

--- a/packages/storybook/src/stories/ActionPanel/actionPanel.stories.tsx
+++ b/packages/storybook/src/stories/ActionPanel/actionPanel.stories.tsx
@@ -1,6 +1,6 @@
 import { ArrowForwardIcon, ClockDashedIcon, EnvelopeOpenIcon, TrashIcon } from '@navikt/aksel-icons';
 import { Meta, StoryObj } from '@storybook/react';
-import { ActionPanel } from '../../../../frontend';
+import { ActionPanel } from 'frontend';
 
 export default {
   title: 'Components/ActionPanel',

--- a/packages/storybook/src/stories/BackButton/backButton.stories.tsx
+++ b/packages/storybook/src/stories/BackButton/backButton.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
+import { BackButton } from 'frontend';
 import { withRouter } from 'storybook-addon-react-router-v6';
-import { BackButton } from '../../../../frontend';
 
 export default {
   title: 'Components/BackButton',

--- a/packages/storybook/src/stories/Footer/footer.stories.ts
+++ b/packages/storybook/src/stories/Footer/footer.stories.ts
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Footer } from '../../../../frontend';
+import { Footer } from 'frontend';
 import { withRouter } from 'storybook-addon-react-router-v6';
 
 export default {

--- a/packages/storybook/src/stories/Header/Header.stories.tsx
+++ b/packages/storybook/src/stories/Header/Header.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { expect, within } from '@storybook/test';
+import { Header } from 'frontend';
 import { withRouter } from 'storybook-addon-react-router-v6';
-import { Header } from '../../../../frontend';
 
 const meta = {
   title: 'Components/Header',
@@ -10,7 +10,6 @@ const meta = {
     withRouter,
     (Story, context) => {
       const { args } = context;
-
       return (
         <div className={args.companyName ? 'isCompany' : ''}>
           <Story />

--- a/packages/storybook/src/stories/Snackbar/snackbar.stories.tsx
+++ b/packages/storybook/src/stories/Snackbar/snackbar.stories.tsx
@@ -1,0 +1,72 @@
+import { Meta } from '@storybook/react';
+import { Snackbar } from 'frontend/src/components/Snackbar/Snackbar.tsx';
+import { SnackbarDuration, SnackbarMessageVariant, useSnackbar } from 'frontend/src/components/Snackbar/useSnackbar.ts';
+import { withRouter } from 'storybook-addon-react-router-v6';
+
+export default {
+  title: 'Components/Snackbar',
+  component: Snackbar,
+  decorators: [withRouter],
+  parameters: {
+    layout: 'fullscreen',
+    docs: { source: { type: 'code' } },
+  },
+} as Meta<typeof Snackbar>;
+
+export const Example = () => {
+  const { openSnackbar, dismissSnackbar, isOpen } = useSnackbar();
+
+  return (
+    <div style={{ padding: 20 }}>
+      <button
+        onClick={() =>
+          openSnackbar({
+            message: 'I am non-dismissable',
+            duration: SnackbarDuration.infinite,
+            variant: 'error',
+            dismissable: false,
+          })
+        }
+      >
+        Non-dismissable
+      </button>
+      {(['success', 'info', 'error'] as SnackbarMessageVariant[]).map((variant) => {
+        return (
+          <button
+            key={variant}
+            onClick={() =>
+              openSnackbar({
+                message: variant,
+                variant,
+                duration: SnackbarDuration.long,
+              })
+            }
+          >
+            Show {variant}
+          </button>
+        );
+      })}
+      {Object.values(SnackbarDuration).map((duration) => {
+        return (
+          <button
+            key={duration}
+            onClick={() =>
+              openSnackbar({
+                message: `Duration: ${duration}`,
+                variant: 'success',
+                duration: duration as SnackbarDuration,
+              })
+            }
+          >
+            {duration}
+          </button>
+        );
+      })}
+      <button onClick={() => dismissSnackbar()} style={{ marginLeft: 20 }}>
+        Close all
+      </button>
+      {isOpen ? <p>Snackbar is open</p> : <p>Snackbar is closed</p>}
+      <Snackbar />
+    </div>
+  );
+};


### PR DESCRIPTION
Snackbar-komponent for mobil og desktop med mulighet som bruker `react-query` for state.
Se eksempler i Storybook. Er tatt i bruk i applikasjonen ved lagring av søk som et eksempel.
Mountes bare globalt (`PageLayout` var naturlig sted), og brukes ellers med `useSnackbar`. 


- Sette message, lengde på toast (0 = uendelig) og velge om den skal være mulig å lukke eller ikke.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)

![image](https://github.com/digdir/dialogporten-frontend/assets/3768832/083cbb97-da23-4a74-b646-890687ed400e)
