### PR TITLE
fix: change default subnet size to 23

### DIFF
--- a/.azure/modules/applicationGateway/main.bicep
+++ b/.azure/modules/applicationGateway/main.bicep
@@ -32,7 +32,7 @@ var bffGatewayBackend = {
     properties: {
       backendAddresses: [
         {
-          fqdn: 'https://${namePrefix}-bff.${containerAppEnvironment.properties.defaultDomain}.${location}.azurecontainerapps.io'
+          fqdn: '${namePrefix}-bff.${containerAppEnvironment.properties.defaultDomain}.${location}.azurecontainerapps.io'
         }
       ]
     }
@@ -53,7 +53,7 @@ var frontendGatewayBackend = {
     properties: {
       backendAddresses: [
         {
-          fqdn: 'https://${namePrefix}-frontend-design-poc.${containerAppEnvironment.properties.defaultDomain}.${location}.azurecontainerapps.io'
+          fqdn: '${namePrefix}-frontend-design-poc.${containerAppEnvironment.properties.defaultDomain}.${location}.azurecontainerapps.io'
         }
       ]
     }
@@ -198,6 +198,9 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2023-04-01' =
         }
       }
     ]
+  }
+  identity: {
+    type: 'SystemAssigned'
   }
 }
 

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -43,6 +43,7 @@ var ingress = {
         }
       ]
     : []
+  allowInsecure: true
 }
 
 resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {

--- a/.azure/modules/vnet/main.bicep
+++ b/.azure/modules/vnet/main.bicep
@@ -14,7 +14,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-09-01' = {
       {
         name: 'default'
         properties: {
-          addressPrefix: '10.0.0.0/24'
+          addressPrefix: '10.0.0.0/23'
         }
       }
       {


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

- change default subnet since to 23 because that is what container apps require
- remove protocol from fqdn
- allow non-ssl requests to container apps

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->