### PR TITLE
feat:  fetch parties from stiched schema (#580)

### DIFF
--- a/packages/bff-types-generated/queries/parties.fragment.graphql
+++ b/packages/bff-types-generated/queries/parties.fragment.graphql
@@ -1,0 +1,6 @@
+fragment partyFields on AuthorizedParty {
+      party
+      partyType
+      isAccessManager
+      isMainAdministrator
+}

--- a/packages/bff-types-generated/queries/parties.graphql
+++ b/packages/bff-types-generated/queries/parties.graphql
@@ -1,0 +1,8 @@
+query parties {
+  parties {
+      ...partyFields
+    subParties {
+       ...partyFields
+    }
+  }
+}

--- a/packages/bff-types-generated/schema.ts
+++ b/packages/bff-types-generated/schema.ts
@@ -1,3 +1,2 @@
-import { schema } from 'bff';
-
-export default schema;
+import { stichedSchema } from 'bff';
+export default stichedSchema;

--- a/packages/bff/src/graphql/api.ts
+++ b/packages/bff/src/graphql/api.ts
@@ -1,15 +1,12 @@
-import { buildHTTPExecutor } from '@graphql-tools/executor-http';
 import { stitchSchemas } from '@graphql-tools/stitch';
 import { AsyncExecutor } from '@graphql-tools/utils';
 import axios from 'axios';
-import { schema_verified_graphql } from 'dialogporten-types-generated';
 import { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
 import { print } from 'graphql';
-import { buildSchema } from 'graphql';
 import { createHandler } from 'graphql-http/lib/use/fastify';
 import config from '../config.ts';
-import { schema } from './schema.ts';
+import { bffSchema, dialogportenSchema } from './schema.ts';
 
 const plugin: FastifyPluginAsync = async (fastify, options) => {
   const remoteExecutor: AsyncExecutor = async ({ document, variables, operationName, context }) => {
@@ -31,12 +28,12 @@ const plugin: FastifyPluginAsync = async (fastify, options) => {
   };
 
   const remoteExecutorSubschema = {
-    schema: buildSchema(schema_verified_graphql),
+    schema: dialogportenSchema,
     executor: remoteExecutor,
   };
 
   const stitchedSchema = stitchSchemas({
-    subschemas: [remoteExecutorSubschema, schema],
+    subschemas: [remoteExecutorSubschema, bffSchema],
   });
 
   fastify.post(

--- a/packages/bff/src/graphql/schema.ts
+++ b/packages/bff/src/graphql/schema.ts
@@ -1,5 +1,11 @@
+import { stitchSchemas } from '@graphql-tools/stitch';
+import { schema_verified_graphql } from 'dialogporten-types-generated';
+import { buildSchema } from 'graphql/index.js';
 import { makeSchema } from 'nexus';
 import * as types from './types/index.ts';
-export const schema = makeSchema({
-  types,
+
+export const dialogportenSchema = buildSchema(schema_verified_graphql);
+export const bffSchema = makeSchema({ types });
+export const stichedSchema = stitchSchemas({
+  subschemas: [bffSchema, dialogportenSchema],
 });

--- a/packages/frontend/src/api/queries.ts
+++ b/packages/frontend/src/api/queries.ts
@@ -1,9 +1,9 @@
-import { HelloQuery, ProfileQuery, getSdk } from 'bff-types-generated';
+import axios from 'axios';
+import { HelloQuery, PartiesQuery, ProfileQuery, getSdk } from 'bff-types-generated';
 import { DialogByIdPayload } from 'dialogporten-types-generated';
 import { GraphQLClient, gql } from 'graphql-request';
-import { SavedSearchDTO } from '../pages/SavedSearches';
-import axios from 'axios';
 import { dialogs } from '../mocks/dialogs.tsx';
+import { SavedSearchDTO } from '../pages/SavedSearches';
 
 const graphQLEndpoint = '/api/graphql';
 const graphQLClient = new GraphQLClient(graphQLEndpoint, { credentials: 'include' });
@@ -17,6 +17,8 @@ export const getSavedSearches = (): Promise<SavedSearchDTO[]> =>
 export const fetchHelloWorld = (): Promise<HelloQuery> => graphQLSDK.hello();
 
 export const fetchProfile = (): Promise<ProfileQuery> => graphQLSDK.profile();
+
+export const fetchParties = (): Promise<PartiesQuery> => graphQLSDK.parties();
 
 /* This will be replaced as soon as both BFF and Dialogporten schemas er stichted together */
 export const fetchDialogByIdExample = (dialogId: string): Promise<DialogByIdPayload> => {

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -1,8 +1,9 @@
+import { PartiesQuery } from 'bff-types-generated';
 import React, { useEffect } from 'react';
-import { useQueryClient } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Footer, Header, Sidebar } from '..';
-import { fetchDialogByIdExample, fetchHelloWorld, fetchProfile } from '../../api/queries.ts';
+import { fetchDialogByIdExample, fetchHelloWorld, fetchParties, fetchProfile } from '../../api/queries.ts';
 import { useAuthenticated } from '../../auth';
 import { FeatureFlagKeys, useFeatureFlag } from '../../featureFlags';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/Inbox';
@@ -16,11 +17,16 @@ export const useUpdateOnLocationChange = (fn: () => void) => {
   }, [location, fn]);
 };
 
+export const useParties = () => useQuery<PartiesQuery>('parties', fetchParties);
+
 export const PageLayout: React.FC = () => {
   const queryClient = useQueryClient();
   const [companyName, setCompanyName] = React.useState<string>('Aker Solutions AS');
   const isCompany = !!companyName;
   const isDebugHeaderScreenEnabled = useFeatureFlag<boolean>(FeatureFlagKeys.EnableDebugHeaderScreen);
+  const { data: partiesData } = useParties();
+  const defaultParty = (partiesData?.parties ?? []).find((party) => party.partyType === 'Person')?.party;
+  console.log('Default party uri used for fetching dialogs: ', defaultParty);
 
   useAuthenticated();
   useUpdateOnLocationChange(() => getSearchStringFromQueryParams(queryClient));


### PR DESCRIPTION
Hente parties for innlogget bruker for å kunne hente dialoger senere (som krever party).

For å kunne generere typer og sdk for `parties`, må bff i tillegg eksportere `stiched schema` (bff + dialogporten) i stedet for rent `bff` schema.

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->