### PR TITLE
refactor(frontend): move out BottomDrawer as its own component

### DIFF
--- a/packages/frontend/src/components/ActionPanel/ActionPanel.tsx
+++ b/packages/frontend/src/components/ActionPanel/ActionPanel.tsx
@@ -2,6 +2,7 @@ import { Button } from '@digdir/designsystemet-react';
 import { XMarkIcon } from '@navikt/aksel-icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { BottomDrawer } from '../BottomDrawer';
 import styles from './actionPanel.module.css';
 
 const BulkHeader: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -10,9 +11,9 @@ const BulkHeader: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
 const BulkFooter: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
-    <div className={styles.bulkFooter}>
-      <div className={styles.actionPanel}>{children}</div>
-    </div>
+    <BottomDrawer>
+      <div className={styles.bulkFooter}>{children}</div>
+    </BottomDrawer>
   );
 };
 
@@ -59,24 +60,26 @@ export function ActionPanel({ actionButtons, onUndoSelection, selectedItemCount 
         </Button>
       </BulkHeader>
       <BulkFooter>
-        <div className={styles.actionButtons}>
-          {actionButtons
-            .filter((actionBtn) => actionBtn.hidden !== true)
-            .map(({ label, onClick, icon, disabled }) => {
-              return (
-                <Button
-                  className={styles.actionButton}
-                  key={label}
-                  onClick={onClick}
-                  disabled={disabled}
-                  variant="tertiary"
-                  size="small"
-                >
-                  <span className={styles.actionButtonIcon}>{icon}</span>
-                  <span className={styles.actionButtonLabel}>{label}</span>
-                </Button>
-              );
-            })}
+        <div className={styles.actionPanel}>
+          <div className={styles.actionButtons}>
+            {actionButtons
+              .filter((actionBtn) => actionBtn.hidden !== true)
+              .map(({ label, onClick, icon, disabled }) => {
+                return (
+                  <Button
+                    className={styles.actionButton}
+                    key={label}
+                    onClick={onClick}
+                    disabled={disabled}
+                    variant="tertiary"
+                    size="small"
+                  >
+                    <span className={styles.actionButtonIcon}>{icon}</span>
+                    <span className={styles.actionButtonLabel}>{label}</span>
+                  </Button>
+                );
+              })}
+          </div>
         </div>
       </BulkFooter>
     </>

--- a/packages/frontend/src/components/ActionPanel/actionPanel.module.css
+++ b/packages/frontend/src/components/ActionPanel/actionPanel.module.css
@@ -44,15 +44,8 @@
 }
 
 .bulkFooter {
-  position: fixed;
-  bottom: 0;
   animation: animateFromBottom 230ms cubic-bezier(.21,1.02,.73,1);
   animation-iteration-count: 1;
-  left: 0;
-  right: 0;
-  display: flex;
-  justify-content: center;
-  z-index: 100;
 }
 
 .actionPanel {

--- a/packages/frontend/src/components/BottomDrawer/BottomDrawer.tsx
+++ b/packages/frontend/src/components/BottomDrawer/BottomDrawer.tsx
@@ -1,0 +1,34 @@
+import React, { useState, useContext } from 'react';
+import { createContext } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './bottomDrawer.module.css';
+
+type ContextType = { current: any } | any;
+const BottomDrawerContext = createContext<ContextType>({});
+
+/*
+ *  Use this to show stuff in the bottom drawer
+ **/
+export const BottomDrawer: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const ref = useContext(BottomDrawerContext);
+
+  if (typeof ref == 'undefined') {
+    return <div></div>;
+  }
+
+  return createPortal(children, ref);
+};
+
+/*
+ *	Wrap the body to support BottomDrawer, it'll be used as a portal target
+ **/
+export const BottomDrawerContainer: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [ref, setRef] = useState<HTMLDivElement | null>();
+
+  return (
+    <>
+      <BottomDrawerContext.Provider value={ref}>{children}</BottomDrawerContext.Provider>
+      <div className={styles.bottomDrawer} ref={(newRef) => setRef(newRef)}></div>
+    </>
+  );
+};

--- a/packages/frontend/src/components/BottomDrawer/bottomDrawer.module.css
+++ b/packages/frontend/src/components/BottomDrawer/bottomDrawer.module.css
@@ -1,0 +1,9 @@
+.bottomDrawer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  z-index: 100;
+}

--- a/packages/frontend/src/components/BottomDrawer/index.ts
+++ b/packages/frontend/src/components/BottomDrawer/index.ts
@@ -1,0 +1,1 @@
+export * from './BottomDrawer';

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -6,6 +6,7 @@ import { Footer, Header, Sidebar } from '..';
 import { fetchHelloWorld, fetchProfile } from '../../api/queries.ts';
 import { useAuthenticated } from '../../auth';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/Inbox';
+import { BottomDrawerContainer } from '../BottomDrawer';
 import { Snackbar } from '../Snackbar/Snackbar.tsx';
 import styles from './pageLayout.module.css';
 
@@ -18,8 +19,8 @@ export const useUpdateOnLocationChange = (fn: () => void) => {
 
 export const PageLayout: React.FC = () => {
   const queryClient = useQueryClient();
-	const urlParams = new URLSearchParams(window.location.search);
-	const debug = urlParams.get('debug') === "true";
+  const urlParams = new URLSearchParams(window.location.search);
+  const debug = urlParams.get('debug') === 'true';
 
   const { isCompany } = useControls({
     isCompany: false,
@@ -30,7 +31,7 @@ export const PageLayout: React.FC = () => {
     fetchBtn: button(async () => {
       const profile = await fetchProfile();
       console.log(profile);
-    })
+    }),
   });
 
   useAuthenticated();
@@ -41,12 +42,14 @@ export const PageLayout: React.FC = () => {
 
   return (
     <div className={isCompany ? `isCompany` : ''}>
-      <div className={styles.pageLayout}>
-        <Header name="John Doe" companyName={isCompany ? 'ACME Corp' : ''} />
-        <Sidebar isCompany={isCompany} />
-        <Outlet />
-        <Footer />
-      </div>
+      <BottomDrawerContainer>
+        <div className={styles.pageLayout}>
+          <Header name="John Doe" companyName={isCompany ? 'ACME Corp' : ''} />
+          <Sidebar isCompany={isCompany} />
+          <Outlet />
+          <Footer />
+        </div>
+      </BottomDrawerContainer>
       <Snackbar />
       <Leva hidden={!debug} />
     </div>

--- a/packages/frontend/src/components/index.ts
+++ b/packages/frontend/src/components/index.ts
@@ -5,3 +5,4 @@ export * from './Sidebar';
 export * from './Footer';
 export * from './ActionPanel';
 export * from './FilterBar';
+export * from './BottomDrawer';

--- a/packages/storybook/src/stories/ActionPanel/actionPanel.stories.tsx
+++ b/packages/storybook/src/stories/ActionPanel/actionPanel.stories.tsx
@@ -1,6 +1,6 @@
 import { ArrowForwardIcon, ClockDashedIcon, EnvelopeOpenIcon, TrashIcon } from '@navikt/aksel-icons';
 import { Meta, StoryObj } from '@storybook/react';
-import { ActionPanel } from 'frontend';
+import { ActionPanel, BottomDrawerContainer } from 'frontend';
 
 export default {
   title: 'Components/ActionPanel',
@@ -8,6 +8,13 @@ export default {
   parameters: {
     layout: 'fullscreen',
   },
+	decorators: [
+		(Story) => (
+			<BottomDrawerContainer>
+				<Story />
+			</BottomDrawerContainer>
+		)
+	],
 } as Meta<typeof ActionPanel>;
 
 export const Default: StoryObj<typeof ActionPanel> = {

--- a/packages/storybook/src/stories/BottomDrawer/bottomDrawer.stories.tsx
+++ b/packages/storybook/src/stories/BottomDrawer/bottomDrawer.stories.tsx
@@ -1,0 +1,34 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { BottomDrawer, BottomDrawerContainer } from 'frontend';
+import { useState } from 'react';
+
+export default {
+  title: 'Components/BottomDrawer',
+  component: BottomDrawer,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as Meta<typeof BottomDrawer>;
+
+export const Example = () => {
+  const [exampleData, setExampleData] = useState(['Drawer 1', 'Drawer 2']);
+
+  const addDrawer = () => {
+    setExampleData((oldData) => [...oldData, `yet another drawer ${oldData.length + 1}`]);
+  };
+
+  return (
+    <>
+      <BottomDrawerContainer>
+        <h2> BottomDrawer example </h2>
+        <button onClick={addDrawer}> Add Drawer </button>
+
+        {exampleData.map((text, i) => (
+          <BottomDrawer key={i}>
+            <div style={{ border: '1px solid black', padding: '4px', margin: '4px' }}>{text}</div>
+          </BottomDrawer>
+        ))}
+      </BottomDrawerContainer>
+    </>
+  );
+};


### PR DESCRIPTION
In preparation for re-using it via a portal in the Snackbar component

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->