### PR TITLE
fix: token not be refreshed when proxied through stiched gql schema

### DIFF
--- a/packages/bff/src/auth/verifyToken.ts
+++ b/packages/bff/src/auth/verifyToken.ts
@@ -4,7 +4,7 @@ import fp from 'fastify-plugin';
 import config from '../config.ts';
 import { SessionStorageToken } from './oidc.ts';
 
-const getIsTokenValid = async (request: FastifyRequest): Promise<boolean> => {
+export const validateOrRefreshToken = async (request: FastifyRequest): Promise<boolean> => {
   const token: SessionStorageToken = request.session.get('token');
 
   if (!token) {
@@ -75,7 +75,7 @@ const getIsTokenValid = async (request: FastifyRequest): Promise<boolean> => {
 
 const plugin: FastifyPluginAsync = async (fastify, _) => {
   fastify.decorate('verifyToken', (request: FastifyRequest, reply: FastifyReply, done) => {
-    getIsTokenValid(request)
+    validateOrRefreshToken(request)
       .then((isValid) => {
         if (isValid) {
           done();


### PR DESCRIPTION
Problem: Når access token utløper, får vi 401 mot Dialogporten selv om access token i session ikke er utløpt.

Mulig teori:
Vi har beskyttet våre egne API-endepunkt ved at tokenet valideres og -- ved behov (access token er utløpt) og mulighet (refresh token er ikke utløpt)  -- fornyes. I koden for GraphQL-stiching hvor vi videresender forespørselen mot Dialogporten, derimot, gjøres det indirekte gjennom at `api/graphql` har en guard for dette.  Det ser derimot ikke ut til å ha noe effekt på token som hentes ut i `remoteExecutor`?

Usikker på denne


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->