### PR TITLE
feature: support multiselect filters 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,5 @@
       "biome check --apply --no-errors-on-unmatched"
     ]
   },
-  "packageManager": "pnpm@8.15.1",
-  "dependencies": {
-    "@playlyfe/gql": "^2.6.2"
-  }
+  "packageManager": "pnpm@8.15.1"
 }

--- a/packages/bff-types-generated/queries/dialog.fragment.graphql
+++ b/packages/bff-types-generated/queries/dialog.fragment.graphql
@@ -17,10 +17,7 @@ fragment SearchDialogFields on SearchDialog {
       cultureCode
     }
     dialogElementId
-    performedBy {
-      value
-      cultureCode
-    }
+    performedBy
   }
   content {
     ...DialogContentFields
@@ -76,14 +73,13 @@ fragment DialogContentFields on Content {
 fragment DialogElement on Element {
     id
     urls {
-      id
-      mimeType
+      mediaType
       consumerType
       url
     }
     type
     displayName {
-            value
+      value
       cultureCode
     }
 }
@@ -93,10 +89,7 @@ fragment DialogActivity on Activity {
     type
     createdAt
     dialogElementId
-    performedBy {
-      value
-      cultureCode
-    }
+    performedBy
 }
 
 fragment SeenLogFields on SeenLog {

--- a/packages/bff-types-generated/queries/savedSearchesFields.fragment.graphql
+++ b/packages/bff-types-generated/queries/savedSearchesFields.fragment.graphql
@@ -6,10 +6,8 @@ fragment SavedSearchesFields on SavedSearches {
     data {
       searchString
       filters {
-        fieldName
+        id
         value
-        label
-        operationName
       }
     }
 }

--- a/packages/bff/src/entities.ts
+++ b/packages/bff/src/entities.ts
@@ -33,23 +33,10 @@ export class ProfileTable {
   deletedAt: Date;
 }
 
-export type FieldOptionOperation = 'equals' | 'includes';
-
-interface ValueFilter {
-  fieldName: string | ((item: Record<string, string | number | boolean>) => string);
-  operation: FieldOptionOperation;
+export interface Filter {
+  id: string;
   value: string;
-  label: string;
 }
-
-export interface UnsetValueFilter {
-  fieldName: string;
-  operation: 'unset';
-  label: string;
-  value?: string | string[];
-}
-
-export type Filter = ValueFilter | UnsetValueFilter;
 
 export interface SavedSearchData {
   filters?: Filter[];

--- a/packages/bff/src/graphql/types/savedSearches.ts
+++ b/packages/bff/src/graphql/types/savedSearches.ts
@@ -1,4 +1,4 @@
-import { extendType, intArg, list, nonNull, objectType, stringArg, arg, inputObjectType } from 'nexus';
+import { arg, extendType, inputObjectType, intArg, list, nonNull, objectType, stringArg } from 'nexus';
 import { SavedSearchRepository } from '../../db.ts';
 import { SavedSearch, getOrCreateProfile } from '../../entities.ts';
 
@@ -14,8 +14,7 @@ export const Mutation = extendType({
         const { id } = args;
         try {
           const result = await SavedSearchRepository!.delete({ id });
-          return { success: result?.affected && result?.affected > 0, message: "Saved search deleted successfully" };
-
+          return { success: result?.affected && result?.affected > 0, message: 'Saved search deleted successfully' };
         } catch (error) {
           console.error('Failed to delete saved search:', error);
           return { success: false, message: 'Failed to delete saved search' };
@@ -46,7 +45,7 @@ export const UpdateSavedSearch = extendType({
         const { id, name } = args;
         try {
           await SavedSearchRepository!.update(id, { name });
-          return { success: true, message: "Saved search updated successfully" };
+          return { success: true, message: 'Saved search updated successfully' };
         } catch (error) {
           console.error('Failed to updated saved search:', error);
           return { success: false, message: 'Failed to updated saved search' };
@@ -93,10 +92,8 @@ export const SavedSearchInput = inputObjectType({
 export const SearchDataValueFilterInput = inputObjectType({
   name: 'SearchDataValueFilterInput',
   definition(t) {
-    t.string('fieldName');
+    t.string('id');
     t.string('value');
-    t.string('label');
-    t.string('operation');
   },
 });
 
@@ -163,10 +160,10 @@ export const SavedSearchData = objectType({
 export const SearchDataValueFilter = objectType({
   name: 'SearchDataValueFilter',
   definition(t) {
-    t.string('fieldName', {
-      description: 'fieldName',
+    t.string('id', {
+      description: 'id',
       resolve: (source, args, ctx, info) => {
-        return source.fieldName;
+        return source.id;
       },
     });
     t.string('value', {
@@ -175,19 +172,5 @@ export const SearchDataValueFilter = objectType({
         return source.value;
       },
     });
-    t.string('label', {
-      description: 'label',
-      resolve: (source, args, ctx, info) => {
-        return source.label;
-      },
-    });
-    t.string('operationName', {
-      description: 'operation',
-      resolve: (source, args, ctx, info) => {
-        return source.operation;
-      },
-    });
   },
 });
-
-

--- a/packages/dialogporten-types-generated/package.json
+++ b/packages/dialogporten-types-generated/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@digdir/dialogporten-schema": "1.0.11",
+    "@digdir/dialogporten-schema": "1.7.1-c19f47a",
     "@graphql-codegen/cli": "^5.0.2",
     "glob": "^10.3.12",
     "graphql": "^16.8.1",

--- a/packages/frontend/src/components/Backdrop/backdrop.module.css
+++ b/packages/frontend/src/components/Backdrop/backdrop.module.css
@@ -6,5 +6,5 @@
   left: 0;
   background-color: rgba(0, 0, 0, 0.5);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
+  z-index: 10;
 }

--- a/packages/frontend/src/components/Backdrop/index.ts
+++ b/packages/frontend/src/components/Backdrop/index.ts
@@ -1,0 +1,1 @@
+export { Backdrop } from './Backdrop.tsx';

--- a/packages/frontend/src/components/FilterBar/AddFilterButton/AddFilterButton.tsx
+++ b/packages/frontend/src/components/FilterBar/AddFilterButton/AddFilterButton.tsx
@@ -1,49 +1,49 @@
 import { Button } from '@digdir/designsystemet-react';
 import { PlusIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
-import { Filter, FilterBarField } from '../FilterBar.tsx';
+import { Filter, FilterSetting, FilterValueType } from '../FilterBar.tsx';
 import { FilterList, FilterListItem } from '../FilterList';
 
 import styles from './addFilterButton.module.css';
 
 type AddFilterButtonProps = {
-  filterOptions: FilterBarField[];
-  filters: Filter[];
-  onListItemClick: (option: FilterBarField) => void;
-  onBtnClick: () => void;
+  settings: FilterSetting[];
+  selectedFilters: Filter[];
+  onListItemClick: (id: string, value: FilterValueType) => void;
+  onAddBtnClick: () => void;
   isOpen: boolean;
   disabled?: boolean;
 };
 export const AddFilterButton = ({
-  filterOptions,
+  settings,
   onListItemClick,
   disabled,
-  filters,
-  onBtnClick,
+  selectedFilters,
+  onAddBtnClick,
   isOpen,
 }: AddFilterButtonProps) => {
   const { t } = useTranslation();
   return (
     <div>
-      <Button size="small" onClick={onBtnClick} disabled={disabled} variant="secondary" color="first">
+      <Button size="small" onClick={onAddBtnClick} disabled={disabled} variant="secondary" color="first">
         <PlusIcon /> {t('filter_bar.add_filter')}
       </Button>
       {isOpen && (
         <FilterList>
-          {filterOptions.map((option: FilterBarField) => {
-            const isUsed = !!filters.find((filter) => filter.fieldName === option.id);
+          {settings.map((setting: FilterSetting) => {
+            const isUsed = !!selectedFilters.find((filter) => filter.id === setting.id);
             return (
               <FilterListItem
-                key={option.id}
+                key={setting.id}
                 disabled={isUsed}
                 onClick={() => {
-                  onListItemClick(option);
+                  onListItemClick(setting.id, undefined);
                 }}
               >
                 <div className={styles.addFilterButtonContent}>
-                  {option.leftIcon}
-                  <span className={styles.addFilterItemLabel}>{option.label}</span>
-                  <span className={styles.addFilterItemCount}>{option.options.length}</span>
+                  {setting.leftIcon}
+                  <span className={styles.addFilterItemLabel}>{setting.label}</span>
+                  <span className={styles.addFilterItemCount}>{setting.options.length}</span>
                 </div>
               </FilterListItem>
             );

--- a/packages/frontend/src/components/FilterBar/AddFilterButton/addFilterButton.module.css
+++ b/packages/frontend/src/components/FilterBar/AddFilterButton/addFilterButton.module.css
@@ -3,6 +3,8 @@
     align-items: center;
     justify-content: space-between;
     column-gap: 1rem;
+    position: relative;
+    z-index: 1001;
 }
 
 .addFilterItemLabel {

--- a/packages/frontend/src/components/FilterBar/FilterList/filterList.module.css
+++ b/packages/frontend/src/components/FilterBar/FilterList/filterList.module.css
@@ -4,6 +4,6 @@
     border-radius: 0.375rem;
     padding: 0.5rem 0;
     position: absolute;
-    z-index: 2;
-    background: white;
+    z-index: 1001;
+    background: #fff;
 }

--- a/packages/frontend/src/components/FilterBar/filterBar.module.css
+++ b/packages/frontend/src/components/FilterBar/filterBar.module.css
@@ -2,15 +2,6 @@
     display: flex;
     align-items: flex-start;
     column-gap: 1em;
-}
-
-.background {
-    position: fixed;
-    height: 100vh;
-    width: 100vw;
-    left: 0;
-    top: 0;
-    z-index: 1;
-    opacity: 0.1;
-    background: black;
+    position: relative;
+    z-index: 1001;
 }

--- a/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
@@ -79,7 +79,7 @@ export const InboxItemDetail = ({
             const attachmentCount = activity.elements.reduce((tail, element) => tail + element.urls.length, 0);
             return (
               <section key={activity.id}>
-                <span>{getPropertyByCultureCode(activity.performedBy)}</span>
+                <span>{activity.performedBy}</span>
                 <div className={styles.elements}>
                   <h2 id="attachmentTitle" className={styles.attachmentTitle}>
                     {t('inbox.attachment.count', {
@@ -96,8 +96,8 @@ export const InboxItemDetail = ({
                                 /* Urls per element are same content in formats */
                                 .filter((url) => url.consumerType === ElementUrlConsumer.Gui)
                                 .map((url) => (
-                                  <li key={url.id}>
-                                    {/* TODO: Icon should render differently depending on url.mimeType */}
+                                  <li key={url.url}>
+                                    {/* TODO: Icon should render differently depending on url.mediaType */}
                                     <FileIcon />
                                     <Link
                                       href={url.url}

--- a/packages/frontend/src/mocks/dialogs.tsx
+++ b/packages/frontend/src/mocks/dialogs.tsx
@@ -1,20 +1,26 @@
 export const dialogs = [
   {
-    id: '49608e01-0329-0572-aaaf-20fbb19d3b4a',
-    revision: '75c6ce94-a81a-4e49-92b3-22f994b14bfd',
-    org: 'ttd',
-    guiAttachmentCount: 4,
-    serviceResource: 'urn:altinn:resource:ttd-dialogporten-automated-tests',
-    party: 'urn:altinn:organization:identifier-no::212475912',
-    createdAt: '2024-03-21T08:55:42.5906890Z',
-    updatedAt: '2024-03-21T08:55:42.5906890Z',
-    status: 'New',
+    id: 'e8e28f01-573b-a971-a728-3b4164f95224',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 5,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-06-04T11:00:21.463Z',
+    updatedAt: '2024-06-04T11:00:21.463Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [],
+    latestActivity: {
+      description: [],
+      dialogElementId: 'a66cbfb8-4bec-4642-a10c-bb06f806b87c',
+      performedBy: null,
+    },
     content: [
       {
         type: 'TITLE',
         value: [
           {
-            value: 'Skjema for rapportering av et eller annet',
+            value: 'Fin tittel',
             cultureCode: 'nb-no',
           },
         ],
@@ -29,124 +35,10 @@ export const dialogs = [
         ],
       },
       {
-        type: 'ADDITIONALINFO',
+        type: 'EXTENDED_STATUS',
         value: [
           {
-            value:
-              'Noe tilsvarende \'body\' i dag (<a href="https://github.com/digdir/dialogporten/blob/main/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/FluentValidation/FluentValidation_LocalizationDto_Extensions.cs">enkel HTML-støtte</a>, inntil 1023 tegn). Ikke påkrevd. Vises kun i detaljvisning.',
-            cultureCode: 'nb-no',
-          },
-        ],
-      },
-    ],
-    elements: [
-      {
-        id: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
-        type: 'super-simple-service:prefill',
-        urls: [
-          {
-            id: '39608e01-0529-0d76-9bab-6c4e361ab37d',
-            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data/9b18d9f2-d197-4e5a-9b80-bdc0872f1a53',
-            mimeType: 'application/json',
-            consumerType: 'Api',
-          },
-        ],
-      },
-      {
-        id: '39608e01-0529-0d76-9bba-00dc83eea40f',
-        displayName: [
-          {
-            value: 'Information Letter',
-            cultureCode: 'en-us',
-          },
-          {
-            value: 'Informasjonsskriv',
-            cultureCode: 'nb-no',
-          },
-        ],
-        urls: [
-          {
-            id: '39608e01-0529-0d76-9bca-dba8582098fb',
-            url: 'https://someexternalsite.com/with/a/document.pdf',
-            mimeType: 'application/pdf',
-            consumerType: 'Gui',
-          },
-          {
-            id: '39608e01-0529-0d76-9bd9-0b5da4b51c10',
-            url: 'https://someexternalsite.com/with/a/document.docx',
-            mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            consumerType: 'Gui',
-          },
-        ],
-      },
-    ],
-    guiActions: [
-      {
-        id: '39608e01-0529-0d76-9bda-19dc3598753b',
-        action: 'submit',
-        url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c',
-        isBackChannel: false,
-        isDeleteAction: false,
-        priority: 'Primary',
-        title: [
-          {
-            value: 'Gå til innsending',
-            cultureCode: 'nb-no',
-          },
-        ],
-      },
-    ],
-    apiActions: [
-      {
-        id: '39608e01-0429-9373-90e5-8548698fc5a0',
-        action: 'submit',
-        endpoints: [
-          {
-            id: '39608e01-0429-9373-90f4-5e49e4855264',
-            version: '20231015',
-            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data?dataType=mainform-20231015',
-            httpMethod: 'POST',
-            requestSchema:
-              'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/api/jsonschema/mainform-20231015',
-            responseSchema: 'https://docs.altinn.studio/swagger/altinn-app-v1.json#/components/schemas/DataElement',
-            deprecated: false,
-          },
-        ],
-      },
-    ],
-    activities: [
-      {
-        id: '39608e01-0429-9373-90cd-c281b4130de7',
-        createdAt: '2024-03-21T08:00:00.0000000Z',
-        type: 'Information',
-        dialogElementId: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
-        performedBy: [
-          {
-            value: 'Norwegian Digitalisation Agency ',
-            cultureCode: 'en-us',
-          },
-          {
-            value: 'Digitaliseringsdirektoratet avd. BOD',
-            cultureCode: 'nb-no',
-          },
-        ],
-        description: [
-          {
-            value: 'Form created and prefilled',
-            cultureCode: 'en-us',
-          },
-          {
-            value: 'Skjema opprettet og forhåndsutfylt',
-            cultureCode: 'nb-no',
-          },
-        ],
-      },
-      {
-        id: '6d26ab76-f957-4229-a4b2-20dbe80df470',
-        createdAt: '2024-03-21T08:55:52.0028870Z',
-        performedBy: [
-          {
-            value: 'Local Development User',
+            value: 'some status max 20',
             cultureCode: 'nb-no',
           },
         ],
@@ -154,20 +46,34 @@ export const dialogs = [
     ],
   },
   {
-    id: '59608e01-0329-0572-aaaf-20fbb19d3b4a',
-    revision: '75c6ce94-a81a-4e49-92b3-22f994b14bfd',
-    org: 'ttd',
-    serviceResource: 'urn:altinn:resource:ttd-dialogporten-automated-tests',
-    party: 'urn:altinn:organization:identifier-no::212475912',
-    createdAt: '2024-03-21T08:55:42.5906890Z',
-    updatedAt: '2024-03-21T08:55:42.5906890Z',
-    status: 'New',
+    id: '82ce8f01-94bd-4775-b8fe-781506f0d348',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-31T11:57:05.811Z',
+    updatedAt: '2024-05-31T11:57:05.811Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [
+      {
+        id: '7a4fbe60-ecc9-4dad-839f-1c92dc694b17',
+        seenAt: '2024-06-03T18:21:24.440Z',
+        endUserName: 'HJELPELINJE ORDINÆR',
+        isCurrentEndUser: true,
+      },
+    ],
+    latestActivity: {
+      description: [],
+      dialogElementId: '8de45330-bf40-4e7d-8541-fa2eeeb979fa',
+      performedBy: null,
+    },
     content: [
       {
         type: 'TITLE',
         value: [
           {
-            value: 'Skjema for rapportering av noe viktig',
+            value: 'Fin tittel',
             cultureCode: 'nb-no',
           },
         ],
@@ -182,124 +88,10 @@ export const dialogs = [
         ],
       },
       {
-        type: 'AdditionalInfo',
+        type: 'EXTENDED_STATUS',
         value: [
           {
-            value:
-              'Noe tilsvarende \'body\' i dag (<a href="https://github.com/digdir/dialogporten/blob/main/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/FluentValidation/FluentValidation_LocalizationDto_Extensions.cs">enkel HTML-støtte</a>, inntil 1023 tegn). Ikke påkrevd. Vises kun i detaljvisning.',
-            cultureCode: 'nb-no',
-          },
-        ],
-      },
-    ],
-    elements: [
-      {
-        id: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
-        type: 'super-simple-service:prefill',
-        urls: [
-          {
-            id: '39608e01-0529-0d76-9bab-6c4e361ab37d',
-            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data/9b18d9f2-d197-4e5a-9b80-bdc0872f1a53',
-            mimeType: 'application/json',
-            consumerType: 'Api',
-          },
-        ],
-      },
-      {
-        id: '39608e01-0529-0d76-9bba-00dc83eea40f',
-        displayName: [
-          {
-            value: 'Information Letter',
-            cultureCode: 'en-us',
-          },
-          {
-            value: 'Informasjonsskriv',
-            cultureCode: 'nb-no',
-          },
-        ],
-        urls: [
-          {
-            id: '39608e01-0529-0d76-9bca-dba8582098fb',
-            url: 'https://someexternalsite.com/with/a/document.pdf',
-            mimeType: 'application/pdf',
-            consumerType: 'Gui',
-          },
-          {
-            id: '39608e01-0529-0d76-9bd9-0b5da4b51c10',
-            url: 'https://someexternalsite.com/with/a/document.docx',
-            mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            consumerType: 'Gui',
-          },
-        ],
-      },
-    ],
-    guiActions: [
-      {
-        id: '39608e01-0529-0d76-9bda-19dc3598753b',
-        action: 'submit',
-        url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c',
-        isBackChannel: false,
-        isDeleteAction: false,
-        priority: 'Primary',
-        title: [
-          {
-            value: 'Gå til innsending',
-            cultureCode: 'nb-no',
-          },
-        ],
-      },
-    ],
-    apiActions: [
-      {
-        id: '39608e01-0429-9373-90e5-8548698fc5a0',
-        action: 'submit',
-        endpoints: [
-          {
-            id: '39608e01-0429-9373-90f4-5e49e4855264',
-            version: '20231015',
-            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data?dataType=mainform-20231015',
-            httpMethod: 'POST',
-            requestSchema:
-              'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/api/jsonschema/mainform-20231015',
-            responseSchema: 'https://docs.altinn.studio/swagger/altinn-app-v1.json#/components/schemas/DataElement',
-            deprecated: false,
-          },
-        ],
-      },
-    ],
-    activities: [
-      {
-        id: '39608e01-0429-9373-90cd-c281b4130de7',
-        createdAt: '2024-03-21T08:00:00.0000000Z',
-        type: 'Information',
-        dialogElementId: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
-        performedBy: [
-          {
-            value: 'Norwegian Digitalisation Agency ',
-            cultureCode: 'en-us',
-          },
-          {
-            value: 'Digitaliseringsdirektoratet avd. BOD',
-            cultureCode: 'nb-no',
-          },
-        ],
-        description: [
-          {
-            value: 'Form created and prefilled',
-            cultureCode: 'en-us',
-          },
-          {
-            value: 'Skjema opprettet og forhåndsutfylt',
-            cultureCode: 'nb-no',
-          },
-        ],
-      },
-      {
-        id: '6d26ab76-f957-4229-a4b2-20dbe80df470',
-        createdAt: '2024-03-21T08:55:52.0028870Z',
-        performedBy: [
-          {
-            value: 'Local Development User',
+            value: 'some status max 20',
             cultureCode: 'nb-no',
           },
         ],
@@ -307,20 +99,27 @@ export const dialogs = [
     ],
   },
   {
-    id: '39608e01-0329-0572-aaaf-20fbb19d3b4a',
-    revision: '75c6ce94-a81a-4e49-92b3-22f994b14bfd',
-    org: 'ttd',
-    serviceResource: 'urn:altinn:resource:ttd-dialogporten-automated-tests',
-    party: 'urn:altinn:organization:identifier-no::212475912',
-    createdAt: '2023-03-21T08:55:42.5906890Z',
-    updatedAt: '2023-03-21T08:55:42.5906890Z',
-    status: 'New',
+    id: 'a6c48f01-3a40-1177-a13e-5ad8b2eca569',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-29T13:59:40.858Z',
+    updatedAt: '2024-05-29T13:59:40.858Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [],
+    latestActivity: {
+      description: [],
+      dialogElementId: '2181c0c1-b219-45b1-8079-fdcc6b66dde3',
+      performedBy: null,
+    },
     content: [
       {
         type: 'TITLE',
         value: [
           {
-            value: 'Skjema for rapportering av noe sånt som det',
+            value: 'Fin tittel',
             cultureCode: 'nb-no',
           },
         ],
@@ -335,124 +134,512 @@ export const dialogs = [
         ],
       },
       {
-        type: 'AdditionalInfo',
+        type: 'EXTENDED_STATUS',
         value: [
           {
-            value:
-              'Noe tilsvarende \'body\' i dag (<a href="https://github.com/digdir/dialogporten/blob/main/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/FluentValidation/FluentValidation_LocalizationDto_Extensions.cs">enkel HTML-støtte</a>, inntil 1023 tegn). Ikke påkrevd. Vises kun i detaljvisning.',
+            value: 'some status max 20',
             cultureCode: 'nb-no',
           },
         ],
       },
     ],
-    elements: [
+  },
+  {
+    id: 'a4c48f01-eead-f672-81b9-7be80f8c4b80',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-29T13:57:57.870Z',
+    updatedAt: '2024-05-29T13:57:57.870Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [],
+    latestActivity: {
+      description: [],
+      dialogElementId: 'fde216bc-b1cc-4684-a930-5be2e844c58b',
+      performedBy: null,
+    },
+    content: [
       {
-        id: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
-        type: 'super-simple-service:prefill',
-        urls: [
+        type: 'TITLE',
+        value: [
           {
-            id: '39608e01-0529-0d76-9bab-6c4e361ab37d',
-            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data/9b18d9f2-d197-4e5a-9b80-bdc0872f1a53',
-            mimeType: 'application/json',
-            consumerType: 'Api',
-          },
-        ],
-      },
-      {
-        id: '39608e01-0529-0d76-9bba-00dc83eea40f',
-        displayName: [
-          {
-            value: 'Information Letter',
-            cultureCode: 'en-us',
-          },
-          {
-            value: 'Informasjonsskriv',
+            value: 'Fin tittel',
             cultureCode: 'nb-no',
           },
         ],
-        urls: [
+      },
+      {
+        type: 'SUMMARY',
+        value: [
           {
-            id: '39608e01-0529-0d76-9bca-dba8582098fb',
-            url: 'https://someexternalsite.com/with/a/document.pdf',
-            mimeType: 'application/pdf',
-            consumerType: 'Gui',
-          },
-          {
-            id: '39608e01-0529-0d76-9bd9-0b5da4b51c10',
-            url: 'https://someexternalsite.com/with/a/document.docx',
-            mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            consumerType: 'Gui',
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
           },
         ],
       },
-    ],
-    guiActions: [
       {
-        id: '39608e01-0529-0d76-9bda-19dc3598753b',
-        action: 'submit',
-        url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c',
-        isBackChannel: false,
-        isDeleteAction: false,
-        priority: 'Primary',
-        title: [
+        type: 'EXTENDED_STATUS',
+        value: [
           {
-            value: 'Gå til innsending',
+            value: 'some status max 20',
             cultureCode: 'nb-no',
           },
         ],
       },
     ],
-    apiActions: [
+  },
+  {
+    id: 'a4c48f01-ce99-1471-b2d0-edf25a8aaac8',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-29T13:57:52.718Z',
+    updatedAt: '2024-05-29T13:57:52.718Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [],
+    latestActivity: {
+      description: [],
+      dialogElementId: '68f2f740-4478-438f-a64b-f4349011893f',
+      performedBy: null,
+    },
+    content: [
       {
-        id: '39608e01-0429-9373-90e5-8548698fc5a0',
-        action: 'submit',
-        endpoints: [
+        type: 'TITLE',
+        value: [
           {
-            id: '39608e01-0429-9373-90f4-5e49e4855264',
-            version: '20231015',
-            url: 'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/#/instance/50756302/58d88b01-8840-8771-a6dd-e51e9809df2c/data?dataType=mainform-20231015',
-            httpMethod: 'POST',
-            requestSchema:
-              'https://digdir.apps.tt02.altinn.no/digdir/super-simple-service/api/jsonschema/mainform-20231015',
-            responseSchema: 'https://docs.altinn.studio/swagger/altinn-app-v1.json#/components/schemas/DataElement',
-            deprecated: false,
+            value: 'Fin tittel',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'SUMMARY',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'EXTENDED_STATUS',
+        value: [
+          {
+            value: 'some status max 20',
+            cultureCode: 'nb-no',
           },
         ],
       },
     ],
-    activities: [
+  },
+  {
+    id: 'a4c48f01-5241-df73-8345-cb5c1ef4ca99',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-29T13:57:30.065Z',
+    updatedAt: '2024-05-29T13:57:30.065Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [],
+    latestActivity: {
+      description: [],
+      dialogElementId: '3411fdc2-b8ec-416f-8fc4-beec70a968e6',
+      performedBy: null,
+    },
+    content: [
       {
-        id: '39608e01-0429-9373-90cd-c281b4130de7',
-        createdAt: '2024-03-21T08:00:00.0000000Z',
-        type: 'Information',
-        dialogElementId: '253abdb5-ce38-4c55-ba27-5d903aa4a481',
-        performedBy: [
+        type: 'TITLE',
+        value: [
           {
-            value: 'Norwegian Digitalisation Agency ',
-            cultureCode: 'en-us',
-          },
-          {
-            value: 'Digitaliseringsdirektoratet avd. BOD',
-            cultureCode: 'nb-no',
-          },
-        ],
-        description: [
-          {
-            value: 'Form created and prefilled',
-            cultureCode: 'en-us',
-          },
-          {
-            value: 'Skjema opprettet og forhåndsutfylt',
+            value: 'Fin tittel',
             cultureCode: 'nb-no',
           },
         ],
       },
       {
-        id: '6d26ab76-f957-4229-a4b2-20dbe80df470',
-        createdAt: '2024-03-21T08:55:52.0028870Z',
-        performedBy: [
+        type: 'SUMMARY',
+        value: [
           {
-            value: 'Local Development Admin',
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'EXTENDED_STATUS',
+        value: [
+          {
+            value: 'some status max 20',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '69c08f01-7586-7972-8d6e-39765fda45f1',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-28T18:14:52.272Z',
+    updatedAt: '2024-05-28T18:14:52.272Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [],
+    latestActivity: {
+      description: [],
+      dialogElementId: '4c07dd98-315d-4476-ac13-1b2f077dac07',
+      performedBy: null,
+    },
+    content: [
+      {
+        type: 'TITLE',
+        value: [
+          {
+            value: 'Fin tittel',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'SUMMARY',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'EXTENDED_STATUS',
+        value: [
+          {
+            value: 'some status max 20',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '24bf8f01-0891-a370-a70a-b2b428a959b1',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-28T12:19:55.784Z',
+    updatedAt: '2024-05-28T12:19:55.784Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [
+      {
+        id: 'b0f1bc05-4cfb-4a78-a998-140b2326f5f3',
+        seenAt: '2024-05-28T12:58:37.369Z',
+        endUserName: 'HJELPELINJE ORDINÆR',
+        isCurrentEndUser: true,
+      },
+    ],
+    latestActivity: {
+      description: [],
+      dialogElementId: '7feace6b-6001-4358-925f-e9d067353755',
+      performedBy: null,
+    },
+    content: [
+      {
+        type: 'TITLE',
+        value: [
+          {
+            value: 'Fin tittel',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'SUMMARY',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'EXTENDED_STATUS',
+        value: [
+          {
+            value: 'some status max 20',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'd6be8f01-51a0-a375-a92b-6a35b3915bcc',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-28T10:54:47.889Z',
+    updatedAt: '2024-05-28T10:54:47.889Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [
+      {
+        id: 'f6ae03a9-2cfd-4b86-9551-4dfbf321b2ac',
+        seenAt: '2024-05-28T10:57:04.339Z',
+        endUserName: 'HJELPELINJE ORDINÆR',
+        isCurrentEndUser: true,
+      },
+    ],
+    latestActivity: {
+      description: [],
+      dialogElementId: 'f608f467-6fd4-41ae-acf8-c423f6616390',
+      performedBy: null,
+    },
+    content: [
+      {
+        type: 'TITLE',
+        value: [
+          {
+            value: 'Fin tittel',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'SUMMARY',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'EXTENDED_STATUS',
+        value: [
+          {
+            value: 'some status max 20',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '7fbb8f01-d59c-a274-9498-2a47015f6935',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-27T19:20:53.717Z',
+    updatedAt: '2024-05-27T19:20:53.717Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [
+      {
+        id: '912ef7b5-250e-44ac-bdc9-4a53174c3f68',
+        seenAt: '2024-05-28T05:09:46.876Z',
+        endUserName: 'HJELPELINJE ORDINÆR',
+        isCurrentEndUser: true,
+      },
+    ],
+    latestActivity: {
+      description: [],
+      dialogElementId: '489f8477-39df-4602-8d9f-8f6940b986a8',
+      performedBy: null,
+    },
+    content: [
+      {
+        type: 'TITLE',
+        value: [
+          {
+            value: 'arst',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'SUMMARY',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'EXTENDED_STATUS',
+        value: [
+          {
+            value: 'some status max 20',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '7dbb8f01-4790-3972-9054-729f3885fa34',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-27T19:18:39.431Z',
+    updatedAt: '2024-05-27T19:18:39.431Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [
+      {
+        id: 'd5134c40-d859-47df-920c-ae3092fad2c1',
+        seenAt: '2024-05-28T07:09:46.850Z',
+        endUserName: 'HJELPELINJE ORDINÆR',
+        isCurrentEndUser: true,
+      },
+    ],
+    latestActivity: {
+      description: [],
+      dialogElementId: '4a75326c-2da0-426a-acf9-cdcefc47488b',
+      performedBy: null,
+    },
+    content: [
+      {
+        type: 'TITLE',
+        value: [
+          {
+            value: 'arst',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'SUMMARY',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'EXTENDED_STATUS',
+        value: [
+          {
+            value: 'some status max 20',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '38aa8f01-3c9c-e474-910f-a51f5bce31aa',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 0,
+    guiAttachmentCount: 2,
+    status: 'NEW',
+    createdAt: '2024-05-24T10:49:47.836Z',
+    updatedAt: '2024-05-24T10:49:47.836Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [
+      {
+        id: 'fbc92a91-1fd8-44cc-91c8-364878e24a9f',
+        seenAt: '2024-05-24T10:50:18.653Z',
+        endUserName: 'HJELPELINJE ORDINÆR',
+        isCurrentEndUser: true,
+      },
+    ],
+    latestActivity: {
+      description: [],
+      dialogElementId: '42d372c8-2e8d-4e7d-bb28-fbee483dfab6',
+      performedBy: null,
+    },
+    content: [
+      {
+        type: 'TITLE',
+        value: [
+          {
+            value: 'Din skattemelding for 2023',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'SUMMARY',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'EXTENDED_STATUS',
+        value: [
+          {
+            value: 'some status max 20',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '10a58f01-b599-4f72-950b-2ddc2c5e8b54',
+    party: 'urn:altinn:organization:identifier-no:212475912',
+    org: 'digdir',
+    progress: 90,
+    guiAttachmentCount: 2,
+    status: 'IN_PROGRESS',
+    createdAt: '2024-05-23T10:47:59.669Z',
+    updatedAt: '2024-05-23T10:47:59.669Z',
+    extendedStatus: null,
+    seenSinceLastUpdate: [
+      {
+        id: '3164dce1-7a15-4281-bf32-0037baf6037d',
+        seenAt: '2024-05-23T11:32:05.482Z',
+        endUserName: 'HJELPELINJE ORDINÆR',
+        isCurrentEndUser: true,
+      },
+    ],
+    latestActivity: {
+      description: [],
+      dialogElementId: 'f997ff01-d7bd-427a-ba29-9560d779424d',
+      performedBy: null,
+    },
+    content: [
+      {
+        type: 'TITLE',
+        value: [
+          {
+            value: 'arst',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'SUMMARY',
+        value: [
+          {
+            value: 'Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.',
+            cultureCode: 'nb-no',
+          },
+        ],
+      },
+      {
+        type: 'EXTENDED_STATUS',
+        value: [
+          {
+            value: 'some status max 20',
             cultureCode: 'nb-no',
           },
         ],

--- a/packages/frontend/src/pages/SavedSearches/EditSearchesItem.tsx
+++ b/packages/frontend/src/pages/SavedSearches/EditSearchesItem.tsx
@@ -1,13 +1,12 @@
-import styles from './savedSearches.module.css';
-import { SavedSearchData, SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { Button, Modal } from '@digdir/designsystemet-react';
+import { SavedSearchData, SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { useState } from 'react';
-import { updateSavedSearch } from '../../api/queries';
+import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import { autoFormatRelativeTime } from '.';
-import { useTranslation } from 'react-i18next';
+import { updateSavedSearch } from '../../api/queries';
 import { useSnackbar } from '../../components/Snackbar/useSnackbar';
-
+import styles from './savedSearches.module.css';
 
 interface EditSavedSearchProps {
   savedSearch?: SavedSearchesFieldsFragment;
@@ -27,54 +26,67 @@ export const EditSavedSearch = ({ savedSearch, onDelete, onClose, isOpen }: Edit
   };
 
   const handleSave = () => {
-    if (!savedSearch?.id) return
+    if (!savedSearch?.id) return;
     updateSavedSearch(savedSearch?.id, searchName).then(() => {
       openSnackbar({
         message: t('savedSearches.update_success'),
         variant: 'success',
       });
       queryClient.invalidateQueries('savedSearches');
-      onClose?.()
+      onClose?.();
     });
   };
 
-  if (!isOpen || !savedSearch?.id) return null
+  if (!isOpen || !savedSearch?.id) return null;
 
-  return <div className={styles.editSavedSearch}>
-    <Modal onInteractOutside={() => console.log("Interact outside")} onBeforeClose={onClose} open={isOpen} onClose={onClose}>
-      <Modal.Header className={styles.editSavedSearchHeader} >
-        <div className={styles.searchDetails}>
-          <span className={styles.searchString}>{searchData?.searchString && `«${searchData.searchString}»`}</span>
-          {searchData?.searchString && `${searchData.filters?.length ? ' + ' : ''}`}
-          {searchData?.filters?.map((search, index) => {
-            const fieldName = search?.fieldName;
-            return (
-              <span key={`${fieldName}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'
-                } ${fieldName}`}</span>
-            );
-          })}
-        </div>
-      </Modal.Header>
-      <Modal.Content>
-        <hr className={styles.horizontalLine} />
-        <div className={styles.searchFormBody}>
-          <label htmlFor="searchName">{t('editSavedSearch.give_search_name')}</label>
-          <input
-            id="searchName"
-            type="text"
-            placeholder={t('editSavedSearch.search_without_name')}
-            value={searchName}
-            onChange={handleSearchNameChange}
-          />
-        </div>
-      </Modal.Content>
-      <Modal.Footer>
-        <div className={styles.searchFormFooter}>
-          <Button className={styles.saveButton} onClick={handleSave}>{t('editSavedSearch.save_and_close')}</Button>
-          <Button variant='secondary' className={styles.deleteButton} onClick={() => onDelete?.(savedSearch?.id)}>{t('word.delete')}</Button>
-          <span className={styles.updateTime}>{t('savedSearches.lastUpdated')}{autoFormatRelativeTime(new Date(parseInt(savedSearch?.updatedAt, 10)))}</span>
-        </div>
-      </Modal.Footer>
-    </Modal>
-  </div>
+  return (
+    <div className={styles.editSavedSearch}>
+      <Modal
+        onInteractOutside={() => console.log('Interact outside')}
+        onBeforeClose={onClose}
+        open={isOpen}
+        onClose={onClose}
+      >
+        <Modal.Header className={styles.editSavedSearchHeader}>
+          <div className={styles.searchDetails}>
+            <span className={styles.searchString}>{searchData?.searchString && `«${searchData.searchString}»`}</span>
+            {searchData?.searchString && `${searchData.filters?.length ? ' + ' : ''}`}
+            {searchData?.filters?.map((search, index) => {
+              const id = search?.id;
+              return (
+                <span key={`${id}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'} ${id}`}</span>
+              );
+            })}
+          </div>
+        </Modal.Header>
+        <Modal.Content>
+          <hr className={styles.horizontalLine} />
+          <div className={styles.searchFormBody}>
+            <label htmlFor="searchName">{t('editSavedSearch.give_search_name')}</label>
+            <input
+              id="searchName"
+              type="text"
+              placeholder={t('editSavedSearch.search_without_name')}
+              value={searchName}
+              onChange={handleSearchNameChange}
+            />
+          </div>
+        </Modal.Content>
+        <Modal.Footer>
+          <div className={styles.searchFormFooter}>
+            <Button className={styles.saveButton} onClick={handleSave}>
+              {t('editSavedSearch.save_and_close')}
+            </Button>
+            <Button variant="secondary" className={styles.deleteButton} onClick={() => onDelete?.(savedSearch?.id)}>
+              {t('word.delete')}
+            </Button>
+            <span className={styles.updateTime}>
+              {t('savedSearches.lastUpdated')}
+              {autoFormatRelativeTime(new Date(parseInt(savedSearch?.updatedAt, 10)))}
+            </span>
+          </div>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
 };

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
@@ -1,10 +1,10 @@
-import styles from './savedSearches.module.css';
-import { compressQueryParams } from '../Inbox/Inbox';
-import { ChevronRightIcon, EllipsisHorizontalIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { SavedSearchData, SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { DropdownMenu } from '@digdir/designsystemet-react';
-import { useTranslation } from 'react-i18next';
+import { ChevronRightIcon, EllipsisHorizontalIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { PencilIcon } from '@navikt/aksel-icons';
+import { SavedSearchData, SavedSearchesFieldsFragment } from 'bff-types-generated';
+import { useTranslation } from 'react-i18next';
+import { compressQueryParams } from '../Inbox/Inbox';
+import styles from './savedSearches.module.css';
 
 interface SavedSearchesItemProps {
   savedSearch?: SavedSearchesFieldsFragment;
@@ -16,17 +16,24 @@ const RenderButtons = ({ savedSearch, onDelete, setSelectedSavedSearch }: SavedS
   const { t } = useTranslation();
   if (!savedSearch?.data) return null;
   const handleOpenEditModal = () => {
-    console.log("Opening edit modal...", { savedSearch, onDelete, setSelectedSavedSearch });
-    setSelectedSavedSearch?.(savedSearch)
-  }
+    console.log('Opening edit modal...', { savedSearch, onDelete, setSelectedSavedSearch });
+    setSelectedSavedSearch?.(savedSearch);
+  };
   return (
     <div style={{ display: 'flex', alignItems: 'center' }}>
       <DropdownMenu>
-        <DropdownMenu.Trigger className={styles.linkButton} ><EllipsisHorizontalIcon className={styles.icon} /></DropdownMenu.Trigger>
+        <DropdownMenu.Trigger className={styles.linkButton}>
+          <EllipsisHorizontalIcon className={styles.icon} />
+        </DropdownMenu.Trigger>
         <DropdownMenu.Content>
           <DropdownMenu.Group>
-            <DropdownMenu.Item onClick={handleOpenEditModal}><PencilIcon fontSize="1.5rem" aria-hidden="true" /> {t('savedSearches.change_name')}</DropdownMenu.Item>
-            <DropdownMenu.Item onClick={() => onDelete?.(savedSearch.id)}><TrashIcon className={styles.icon} aria-hidden="true" />{t('savedSearches.delete_search')}</DropdownMenu.Item>
+            <DropdownMenu.Item onClick={handleOpenEditModal}>
+              <PencilIcon fontSize="1.5rem" aria-hidden="true" /> {t('savedSearches.change_name')}
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onClick={() => onDelete?.(savedSearch.id)}>
+              <TrashIcon className={styles.icon} aria-hidden="true" />
+              {t('savedSearches.delete_search')}
+            </DropdownMenu.Item>
           </DropdownMenu.Group>
         </DropdownMenu.Content>
       </DropdownMenu>
@@ -46,7 +53,11 @@ export const SavedSearchesItem = ({ savedSearch, onDelete, setSelectedSavedSearc
       <>
         <div className={styles.savedSearchItem} key={savedSearch.id}>
           <div className={styles.searchDetails}>{savedSearch.name}</div>
-          <RenderButtons setSelectedSavedSearch={setSelectedSavedSearch} savedSearch={savedSearch} onDelete={onDelete} />
+          <RenderButtons
+            setSelectedSavedSearch={setSelectedSavedSearch}
+            savedSearch={savedSearch}
+            onDelete={onDelete}
+          />
         </div>
         <hr />
       </>
@@ -59,14 +70,18 @@ export const SavedSearchesItem = ({ savedSearch, onDelete, setSelectedSavedSearc
           <span className={styles.searchString}>{searchData?.searchString && `«${searchData.searchString}»`}</span>
           {searchData?.searchString && `${searchData.filters?.length ? ' + ' : ''}`}
           {searchData?.filters?.map((search, index) => {
-            const fieldName = search?.fieldName;
+            const id = search?.id;
             return (
-              <span key={`${fieldName}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'
-                } ${fieldName}`}</span>
+              <span key={`${id}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'} ${id}`}</span>
             );
           })}
         </div>
-        <RenderButtons key={savedSearch.id} setSelectedSavedSearch={setSelectedSavedSearch} savedSearch={savedSearch} onDelete={onDelete} />
+        <RenderButtons
+          key={savedSearch.id}
+          setSelectedSavedSearch={setSelectedSavedSearch}
+          savedSearch={savedSearch}
+          onDelete={onDelete}
+        />
       </div>
       <hr />
     </>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      '@playlyfe/gql':
-        specifier: ^2.6.2
-        version: 2.6.2
     devDependencies:
       '@biomejs/biome':
         specifier: 1.5.3
@@ -240,8 +236,8 @@ importers:
   packages/dialogporten-types-generated:
     dependencies:
       '@digdir/dialogporten-schema':
-        specifier: 1.0.11
-        version: 1.0.11
+        specifier: 1.7.1-c19f47a
+        version: 1.7.1-c19f47a
       '@graphql-codegen/cli':
         specifier: ^5.0.2
         version: 5.0.2(graphql@16.8.1)
@@ -2481,8 +2477,8 @@ packages:
     resolution: {integrity: sha512-e4gQQwHWzxh6Q8kOKdlhXw5gcZwBI0klBEUjuCSDf3NyTcKFdxPDl/pxyl80tpeWfy9GGF4tz5wKmIEKt9YhIg==}
     dev: false
 
-  /@digdir/dialogporten-schema@1.0.11:
-    resolution: {integrity: sha512-fidVFbuu0HLL+nM1RUNjQvdCHL0y6NYAda+VWgjpguZMdXawD7aZMqNh2/e2ItEn2tth5xt8B290JRRPs1lq5g==}
+  /@digdir/dialogporten-schema@1.7.1-c19f47a:
+    resolution: {integrity: sha512-ptvFxbfK6YION4fZo7KMo/5/cOGxT9xuN7TwxcOxv4iu5+dDGzeaMs1XRwtJWfNDQm/mCpDN1CKsLrV84BKeAA==}
     dev: false
 
   /@discoveryjs/json-ext@0.5.7:
@@ -5574,29 +5570,6 @@ packages:
     engines: {node: '>=14'}
     requiresBuild: true
     optional: true
-
-  /@playlyfe/gql@2.6.2:
-    resolution: {integrity: sha512-jsucveVNbF3NGpFdw0fDRqT6Ma2EMUPxEXCRqbs5m7GaMryyirZSo8soR8wo5+8Hv6r6RqStLV32LHftOPyEjw==}
-    dependencies:
-      apollo-codegen: 0.10.13
-      babel-runtime: 6.23.0
-      dentist: 1.0.3
-      fb-watchman: 2.0.0
-      find-config: 1.0.0
-      flow-runtime: 0.14.0
-      graphql: 0.9.6
-      graphql-language-service-interface: 0.0.11
-      graphql-language-service-parser: 0.0.10
-      invariant: 2.2.2
-      json5: 0.5.1
-      keymirror: 0.1.1
-      leven: 2.1.0
-      lodash: 4.17.15
-      minimatch: 3.0.4
-      node-ipc: 9.0.1
-      parse-glob: 3.0.4
-      promise-retry: 1.1.1
-    dev: false
 
   /@playwright/test@1.41.2:
     resolution: {integrity: sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==}
@@ -9185,11 +9158,6 @@ packages:
     hasBin: true
     dev: false
 
-  /ansi-regex@2.1.1:
-    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -9228,23 +9196,6 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-
-  /apollo-codegen@0.10.13:
-    resolution: {integrity: sha512-ZZyC/DuDsJpd6zFpoMntJFdZR/IjCnJ18mvaahX2eNRfeGhJM5Uzt2ipDER7kH8dS1iwkMat+F7vC+gUULwOTQ==}
-    engines: {node: '>=4.0'}
-    deprecated: The 'apollo-codegen' command has been replaced with the more-powerful 'apollo' CLI. Switch to 'apollo' to ensure future updates and visit https://npm.im/apollo#code-generation for more information.
-    hasBin: true
-    dependencies:
-      babel-runtime: 6.23.0
-      change-case: 3.1.0
-      glob: 7.2.3
-      graphql: 0.9.6
-      inflected: 1.1.7
-      mkdirp: 0.5.6
-      node-fetch: 1.7.3
-      source-map-support: 0.4.18
-      yargs: 7.1.2
-    dev: false
 
   /app-root-dir@1.0.2:
     resolution: {integrity: sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==}
@@ -9655,13 +9606,6 @@ packages:
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.9)
     dev: true
 
-  /babel-runtime@6.23.0:
-    resolution: {integrity: sha512-9Vdluea/MpskdLsLYTH10Wtc5z2U0THGHVJeqec0EHUbfEt2q3zM1piQ+/GjMl9h0drUY1hF8zHV9nmH8Kl+Og==}
-    dependencies:
-      core-js: 2.6.12
-      regenerator-runtime: 0.10.5
-    dev: false
-
   /bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -9912,23 +9856,11 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  /camel-case@3.0.0:
-    resolution: {integrity: sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==}
-    dependencies:
-      no-case: 2.3.2
-      upper-case: 1.1.3
-    dev: false
-
   /camel-case@4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
       tslib: 2.6.2
-
-  /camelcase@3.0.0:
-    resolution: {integrity: sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -10036,29 +9968,6 @@ packages:
       title-case: 3.0.3
       upper-case: 2.0.2
       upper-case-first: 2.0.2
-
-  /change-case@3.1.0:
-    resolution: {integrity: sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==}
-    dependencies:
-      camel-case: 3.0.0
-      constant-case: 2.0.0
-      dot-case: 2.1.1
-      header-case: 1.0.1
-      is-lower-case: 1.1.3
-      is-upper-case: 1.1.2
-      lower-case: 1.1.4
-      lower-case-first: 1.0.2
-      no-case: 2.3.2
-      param-case: 2.1.1
-      pascal-case: 2.0.1
-      path-case: 2.1.1
-      sentence-case: 2.1.1
-      snake-case: 2.1.0
-      swap-case: 1.1.2
-      title-case: 2.1.1
-      upper-case: 1.1.3
-      upper-case-first: 1.1.2
-    dev: false
 
   /change-case@4.1.2:
     resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
@@ -10247,14 +10156,6 @@ packages:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
 
-  /cliui@3.2.0:
-    resolution: {integrity: sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==}
-    dependencies:
-      string-width: 1.0.2
-      strip-ansi: 3.0.1
-      wrap-ansi: 2.1.0
-    dev: false
-
   /cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
     dependencies:
@@ -10318,11 +10219,6 @@ packages:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
-
-  /code-point-at@1.1.0:
-    resolution: {integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -10501,13 +10397,6 @@ packages:
     engines: {node: ^14.18.0 || >=16.10.0}
     dev: true
 
-  /constant-case@2.0.0:
-    resolution: {integrity: sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==}
-    dependencies:
-      snake-case: 2.1.0
-      upper-case: 1.1.3
-    dev: false
-
   /constant-case@3.0.4:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
     dependencies:
@@ -10611,12 +10500,6 @@ packages:
   /core-js@1.2.7:
     resolution: {integrity: sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==}
     deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
-    dev: false
-
-  /core-js@2.6.12:
-    resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
-    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
-    requiresBuild: true
     dev: false
 
   /core-js@3.35.1:
@@ -11500,10 +11383,6 @@ packages:
     engines: {node: '>=0.10'}
     dev: false
 
-  /dentist@1.0.3:
-    resolution: {integrity: sha512-WhvkR39y22OyhczYWquFYAuSk6iRUUUra69kq+xLksC1VrKMZQjStzJsdTHRMN1epqOzdF1LbDKxWaT+RAr6fA==}
-    dev: false
-
   /depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
     engines: {node: '>= 0.6'}
@@ -11726,12 +11605,6 @@ packages:
       domhandler: 5.0.3
     dev: false
 
-  /dot-case@2.1.1:
-    resolution: {integrity: sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==}
-    dependencies:
-      no-case: 2.3.2
-    dev: false
-
   /dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
@@ -11773,11 +11646,6 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: false
-
-  /easy-stack@1.0.1:
-    resolution: {integrity: sha512-wK2sCs4feiiJeFXn3zvY0p41mdU5VUgbgs1rNsc/y5ngFUijdWd+iIN8eoyuZHKB8xN6BL4PdWmzqFmxNg6V2w==}
-    engines: {node: '>=6.0.0'}
     dev: false
 
   /ecdsa-sig-formatter@1.0.11:
@@ -11843,12 +11711,6 @@ packages:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
 
-  /encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-    dependencies:
-      iconv-lite: 0.6.3
-    dev: false
-
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
@@ -11878,10 +11740,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
     dev: true
-
-  /err-code@1.1.2:
-    resolution: {integrity: sha512-CJAN+O0/yA1CKfRn9SXOGctSpEM7DCon/r/5r2eXFMY2zCCJBasFhcM5I+1kh3Ap11FsQCX+vGHceNPvpWKhoA==}
-    dev: false
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -12172,11 +12030,6 @@ packages:
       require-like: 0.1.2
     dev: false
 
-  /event-pubsub@4.2.4:
-    resolution: {integrity: sha512-Vl1ark+g0gDWqIckUk+0KzIrrJuM4wQxBv+QvG4LjVTOI5NJJBkpU6LcNHDWW2u9e61hEH505fggVdlP6e2vqg==}
-    engines: {node: '>=4.0.0'}
-    dev: false
-
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -12444,12 +12297,6 @@ packages:
       websocket-driver: 0.7.4
     dev: false
 
-  /fb-watchman@2.0.0:
-    resolution: {integrity: sha512-+6dk4acfiWsbMc8pH0boQDeQprOM4mO/kS4IAvZVJZk4B6CZYLg4DkTGbL82vhglUXDtkJPnLfO0WXv3uxGNfA==}
-    dependencies:
-      bser: 2.1.1
-    dev: false
-
   /fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
     dependencies:
@@ -12585,13 +12432,6 @@ packages:
       pkg-dir: 7.0.0
     dev: false
 
-  /find-config@1.0.0:
-    resolution: {integrity: sha512-Z+suHH+7LSE40WfUeZPIxSxypCWvrzdVc60xAjUShZeT5eMWM0/FQUduq3HjluyfAHWvC/aOBkT1pTZktyF/jg==}
-    engines: {node: '>= 0.12'}
-    dependencies:
-      user-home: 2.0.0
-    dev: false
-
   /find-file-up@0.1.3:
     resolution: {integrity: sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==}
     engines: {node: '>=0.10.0'}
@@ -12626,14 +12466,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /find-up@1.1.2:
-    resolution: {integrity: sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      path-exists: 2.1.0
-      pinkie-promise: 2.0.1
-    dev: false
 
   /find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
@@ -12684,10 +12516,6 @@ packages:
     resolution: {integrity: sha512-xPWkzCO07AnS8X+fQFpWm+tJ+C7aeaiVzJ+rSepbkCXUvUJ6l6squEl63axoMcixyH4wLjmypOzq/+zTD0O93w==}
     engines: {node: '>=0.4.0'}
     dev: true
-
-  /flow-runtime@0.14.0:
-    resolution: {integrity: sha512-782tOJxoHyN/roNm6NvmAISlbtl1NPnFHw4AsLMq8LnAlJK61K0TqSirdJwHMSET03nTEBA4YYRh91XjFIbVkg==}
-    dev: false
 
   /follow-redirects@1.15.5(debug@4.3.4):
     resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
@@ -12913,10 +12741,6 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  /get-caller-file@1.0.3:
-    resolution: {integrity: sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==}
-    dev: false
-
   /get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -12989,20 +12813,6 @@ packages:
   /github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
     dev: true
-
-  /glob-base@0.3.0:
-    resolution: {integrity: sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      glob-parent: 2.0.0
-      is-glob: 2.0.1
-    dev: false
-
-  /glob-parent@2.0.0:
-    resolution: {integrity: sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==}
-    dependencies:
-      is-glob: 2.0.1
-    dev: false
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -13238,45 +13048,6 @@ packages:
       graphql: 16.8.1
     dev: false
 
-  /graphql-language-service-config@0.0.11:
-    resolution: {integrity: sha512-Ob42MBclRjiWJZ3Z5C+OE5qei7S9oUutqdB1ICXrby/jI1Af5/qZfqJN2W1+TzShF4zKsUpIj9YNAnjpVVVauA==}
-    dependencies:
-      graphql-language-service-types: 0.0.16
-    dev: false
-
-  /graphql-language-service-interface@0.0.11:
-    resolution: {integrity: sha512-OAg5fBU93273z+xP9ghD9O+8DUFd8Ni9z8W7XhsBMMEW4Gths5TW8yxZEF44Q1VmWklLN3nXtQb0hfO1M3F+Aw==}
-    deprecated: this package has been merged into graphql-language-service
-    dependencies:
-      graphql: 0.9.6
-      graphql-language-service-config: 0.0.11
-      graphql-language-service-parser: 0.0.10
-      graphql-language-service-types: 0.0.16
-      graphql-language-service-utils: 0.0.10
-    dev: false
-
-  /graphql-language-service-parser@0.0.10:
-    resolution: {integrity: sha512-plHclXYo72d/KlLvuwQak65sSHNu1LbduHasAHj6XQMX7nJagri+TrJ9CldTk0dDpTegtSaRRQcJ5PE279ziWQ==}
-    deprecated: this package has been merged into graphql-language-service
-    dependencies:
-      graphql-language-service-types: 0.0.16
-    dev: false
-
-  /graphql-language-service-types@0.0.16:
-    resolution: {integrity: sha512-j094/a5GOQOFeNLgY+mQvKOv4oWBDV+ZhoyJ8BPObfCirJlzu9oEF9F8hM4wHmt1xhvGEiYJMBjhp98FjvZfJA==}
-    deprecated: this package has been merged into graphql-language-service
-    dependencies:
-      graphql: 0.9.6
-    dev: false
-
-  /graphql-language-service-utils@0.0.10:
-    resolution: {integrity: sha512-5lwqGW//z+1u+14A6AHXzShjjj6ucLLtG/psYF9L22kKi1eA/HWKih6+DvLAHDhzOTObIIYS0ZIRuhm3MXwI1A==}
-    deprecated: this package has been merged into graphql-language-service
-    dependencies:
-      graphql: 0.9.6
-      graphql-language-service-types: 0.0.16
-    dev: false
-
   /graphql-request@6.1.0(graphql@16.8.1):
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
     peerDependencies:
@@ -13323,12 +13094,6 @@ packages:
       graphql: '>=0.11 <=16'
     dependencies:
       graphql: 16.8.1
-    dev: false
-
-  /graphql@0.9.6:
-    resolution: {integrity: sha512-fdfawcX2SV68cwZp1iv4UMrDnuBROT1EtWmgs36CuF4N5HgOgMUKX1bf4sZZF16FBwbZWaU948k5Fay7AJqqXQ==}
-    dependencies:
-      iterall: 1.3.0
     dev: false
 
   /graphql@16.8.1:
@@ -13561,13 +13326,6 @@ packages:
     hasBin: true
     dev: false
 
-  /header-case@1.0.1:
-    resolution: {integrity: sha512-i0q9mkOeSuhXw6bGgiQCCBgY/jlZuV/7dZXyZ9c6LcBrqwvT8eT719E9uxE5LiZftdl+z81Ugbg/VvXV4OJOeQ==}
-    dependencies:
-      no-case: 2.3.2
-      upper-case: 1.1.3
-    dev: false
-
   /header-case@2.0.4:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
@@ -13612,6 +13370,7 @@ packages:
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+    dev: true
 
   /hotkeys-js@3.13.7:
     resolution: {integrity: sha512-ygFIdTqqwG4fFP7kkiYlvayZppeIQX2aPpirsngkv1xM1lP0piDY5QEh68nQnIKvz64hfocxhBaD/uK3sSK1yQ==}
@@ -13984,10 +13743,6 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /inflected@1.1.7:
-    resolution: {integrity: sha512-3lz7idKIPmKvz0wqlu1PUPSg5strJnCh2v2NldPQy13Fmd6WsWQ5yExDoiIX48lQ9mo8N7ztdDlkZxOauZ/E5g==}
-    dev: false
-
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
@@ -14073,21 +13828,10 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /invariant@2.2.2:
-    resolution: {integrity: sha512-FUiAFCOgp7bBzHfa/fK+Uc/vqywvdN9Wg3CiTprLcE630mrhxjDS5MlBkHzeI6+bC/6bq9VX/hxBt05fPAT5WA==}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: false
-
   /invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
     dependencies:
       loose-envify: 1.4.0
-
-  /invert-kv@1.0.0:
-    resolution: {integrity: sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /ioredis@5.4.0:
     resolution: {integrity: sha512-lGiiZyWFOskPu3pH4P8+uicHOZHpzYpgfKZFre68wLK6059zBo+KDTQpwxAVibBajKqpcrRJ5k+jl/uNHcCo3A==}
@@ -14213,11 +13957,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  /is-dotfile@1.0.3:
-    resolution: {integrity: sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
@@ -14230,21 +13969,9 @@ packages:
       is-plain-object: 2.0.4
     dev: false
 
-  /is-extglob@1.0.0:
-    resolution: {integrity: sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-
-  /is-fullwidth-code-point@1.0.0:
-    resolution: {integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      number-is-nan: 1.0.1
-    dev: false
 
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -14273,13 +14000,6 @@ packages:
     dependencies:
       has-tostringtag: 1.0.0
 
-  /is-glob@2.0.1:
-    resolution: {integrity: sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extglob: 1.0.0
-    dev: false
-
   /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -14305,12 +14025,6 @@ packages:
   /is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
-
-  /is-lower-case@1.1.3:
-    resolution: {integrity: sha512-+5A1e/WJpLLXZEDlgz4G//WYSHyQBD32qa4Jd3Lw06qQlv3fJHnp3YIHjTQSGzHMgzmVKz2ZP3rBxTHkPw/lxA==}
-    dependencies:
-      lower-case: 1.1.4
-    dev: false
 
   /is-lower-case@2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
@@ -14428,11 +14142,6 @@ packages:
       call-bind: 1.0.5
     dev: true
 
-  /is-stream@1.1.0:
-    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -14474,20 +14183,10 @@ packages:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
 
-  /is-upper-case@1.1.2:
-    resolution: {integrity: sha512-GQYSJMgfeAmVwh9ixyk888l7OIhNAGKtY6QA+IrWlu9MDTCaXmeozOZ2S9Knj7bQwBO/H6J2kb+pbyTUiMNbsw==}
-    dependencies:
-      upper-case: 1.1.3
-    dev: false
-
   /is-upper-case@2.0.2:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
     dependencies:
       tslib: 2.6.2
-
-  /is-utf8@0.2.1:
-    resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
-    dev: false
 
   /is-weakmap@2.0.1:
     resolution: {integrity: sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==}
@@ -15173,18 +14872,6 @@ packages:
     resolution: {integrity: sha512-6ScbIk2WWCeXkmzF6bRPmEuaqy1m8SbsRFMa/FLrSCkGIhj8OLVG/IH+XHVmNMx/KUo8cVWEE6oKR4dJ+S0Rkg==}
     dev: false
 
-  /js-message@1.0.5:
-    resolution: {integrity: sha512-hTqHqrm7jrZ+iN93QsKcNOTSgX3F+2NSgdnF+xvf8FfhC2MPqYRzzgXQ1LlhfyIzPTS6hL6Zea0/gIb6hktkHw==}
-    engines: {node: '>=0.6.0'}
-    dev: false
-
-  /js-queue@2.0.0:
-    resolution: {integrity: sha512-SW0rTTG+TBPVD1Kp6HtnOr9kX3//EWA6qMlP2Y/WxbKsSNCBuJbWv3EDB5noKJBEkHYi2mDY+xqMn4Y0QHyjyg==}
-    engines: {node: '>=1.0.0'}
-    dependencies:
-      easy-stack: 1.0.1
-    dev: false
-
   /js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
     dev: false
@@ -15324,11 +15011,6 @@ packages:
       remove-trailing-spaces: 1.0.8
     dev: false
 
-  /json5@0.5.1:
-    resolution: {integrity: sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==}
-    hasBin: true
-    dev: false
-
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -15394,10 +15076,6 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /keymirror@0.1.1:
-    resolution: {integrity: sha512-vIkZAFWoDijgQT/Nvl2AHCMmnegN2ehgTPYuyy2hWQkQSntI0S7ESYqdLkoSe1HyEBFHHkCgSIvVdSEiWwKvCg==}
-    dev: false
-
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
@@ -15453,13 +15131,6 @@ packages:
       dotenv-expand: 10.0.0
     dev: true
 
-  /lcid@1.0.0:
-    resolution: {integrity: sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      invert-kv: 1.0.0
-    dev: false
-
   /leva@0.9.35(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-sp/ZbHGrrzM+eq+wIAc9X7C5qFagNERYkwaulKI/xy0XrDPV67jLUSSqTCFSoSc0Uk96j3oephYoO/6I8mZNuw==}
     peerDependencies:
@@ -15482,11 +15153,6 @@ packages:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
-    dev: false
-
-  /leven@2.1.0:
-    resolution: {integrity: sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /leven@3.1.0:
@@ -15571,17 +15237,6 @@ packages:
       rfdc: 1.3.1
       wrap-ansi: 9.0.0
     dev: true
-
-  /load-json-file@1.1.0:
-    resolution: {integrity: sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      graceful-fs: 4.2.11
-      parse-json: 2.2.0
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
-      strip-bom: 2.0.0
-    dev: false
 
   /loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
@@ -15705,10 +15360,6 @@ packages:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
     dev: false
 
-  /lodash@4.17.15:
-    resolution: {integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==}
-    dev: false
-
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -15754,20 +15405,10 @@ packages:
     dependencies:
       get-func-name: 2.0.2
 
-  /lower-case-first@1.0.2:
-    resolution: {integrity: sha512-UuxaYakO7XeONbKrZf5FEgkantPf5DUqDayzP5VXZrtRPdH86s4kN47I8B3TW10S4QKiE3ziHNf3kRN//okHjA==}
-    dependencies:
-      lower-case: 1.1.4
-    dev: false
-
   /lower-case-first@2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
       tslib: 2.6.2
-
-  /lower-case@1.1.4:
-    resolution: {integrity: sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==}
-    dev: false
 
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -16770,12 +16411,6 @@ packages:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
     dev: false
 
-  /minimatch@3.0.4:
-    resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
-    dependencies:
-      brace-expansion: 1.1.11
-    dev: false
-
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -16839,13 +16474,6 @@ packages:
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
     dev: true
-
-  /mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
-    dependencies:
-      minimist: 1.2.8
-    dev: false
 
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -16997,12 +16625,6 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /no-case@2.3.2:
-    resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
-    dependencies:
-      lower-case: 1.1.4
-    dev: false
-
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
@@ -17055,13 +16677,6 @@ packages:
     resolution: {integrity: sha512-bW9T/uJDPAJB2YNYEpWzE54U5O3MQidXsOyTfnbKYtTtFexRvGzb1waphBN4ZwP6EcIvYYEOwW0b72BpAqydTw==}
     dev: true
 
-  /node-fetch@1.7.3:
-    resolution: {integrity: sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==}
-    dependencies:
-      encoding: 0.1.13
-      is-stream: 1.1.0
-    dev: false
-
   /node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -17093,15 +16708,6 @@ packages:
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
-
-  /node-ipc@9.0.1:
-    resolution: {integrity: sha512-B973ZFnfphVauIuroEPTyzi5zPKgKhn2m3c1ZA6lvULELcd4ItUmHlYemvxU4CgfpUmTAqFjok8XZe/+0tVNpQ==}
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      event-pubsub: 4.2.4
-      js-message: 1.0.5
-      js-queue: 2.0.0
-    dev: false
 
   /node-preload@0.2.1:
     resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}
@@ -17154,6 +16760,7 @@ packages:
       resolve: 1.22.8
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
+    dev: true
 
   /normalize-path@2.1.1:
     resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
@@ -17205,11 +16812,6 @@ packages:
 
   /nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
-
-  /number-is-nan@1.0.1:
-    resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /nwsapi@2.2.7:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
@@ -17432,13 +17034,7 @@ packages:
   /os-homedir@1.0.2:
     resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
     engines: {node: '>=0.10.0'}
-
-  /os-locale@1.4.0:
-    resolution: {integrity: sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      lcid: 1.0.0
-    dev: false
+    dev: true
 
   /os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
@@ -17556,12 +17152,6 @@ packages:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
     dev: true
 
-  /param-case@2.1.1:
-    resolution: {integrity: sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==}
-    dependencies:
-      no-case: 2.3.2
-    dev: false
-
   /param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
@@ -17593,23 +17183,6 @@ packages:
       is-absolute: 1.0.0
       map-cache: 0.2.2
       path-root: 0.1.1
-
-  /parse-glob@3.0.4:
-    resolution: {integrity: sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      glob-base: 0.3.0
-      is-dotfile: 1.0.3
-      is-extglob: 1.0.0
-      is-glob: 2.0.1
-    dev: false
-
-  /parse-json@2.2.0:
-    resolution: {integrity: sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      error-ex: 1.3.2
-    dev: false
 
   /parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -17659,37 +17232,17 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
-  /pascal-case@2.0.1:
-    resolution: {integrity: sha512-qjS4s8rBOJa2Xm0jmxXiyh1+OFf6ekCWOvUaRgAQSktzlTbMotS0nmG9gyYAybCWBcuP4fsBeRCKNwGBnMe2OQ==}
-    dependencies:
-      camel-case: 3.0.0
-      upper-case-first: 1.1.2
-    dev: false
-
   /pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
       tslib: 2.6.2
 
-  /path-case@2.1.1:
-    resolution: {integrity: sha512-Ou0N05MioItesaLr9q8TtHVWmJ6fxWdqKB2RohFmNWVyJ+2zeKIeDNWAN6B/Pe7wpzWChhZX6nONYmOnMeJQ/Q==}
-    dependencies:
-      no-case: 2.3.2
-    dev: false
-
   /path-case@3.0.4:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
     dependencies:
       dot-case: 3.0.4
       tslib: 2.6.2
-
-  /path-exists@2.1.0:
-    resolution: {integrity: sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      pinkie-promise: 2.0.1
-    dev: false
 
   /path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -17764,15 +17317,6 @@ packages:
   /path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
     dev: true
-
-  /path-type@1.1.0:
-    resolution: {integrity: sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      graceful-fs: 4.2.11
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
-    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -17876,28 +17420,11 @@ packages:
     hasBin: true
     dev: true
 
-  /pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
     requiresBuild: true
     dev: true
-
-  /pinkie-promise@2.0.1:
-    resolution: {integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      pinkie: 2.0.4
-    dev: false
-
-  /pinkie@2.0.4:
-    resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /pino-abstract-transport@1.1.0:
     resolution: {integrity: sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==}
@@ -18532,14 +18059,6 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
-  /promise-retry@1.1.1:
-    resolution: {integrity: sha512-StEy2osPr28o17bIW776GtwO6+Q+M9zPiZkYfosciUUMYqjhU/ffwRAH0zN2+uvGyUsn8/YICIHRzLbPacpZGw==}
-    engines: {node: '>=0.12'}
-    dependencies:
-      err-code: 1.1.2
-      retry: 0.10.1
-    dev: false
-
   /promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
     dependencies:
@@ -19095,14 +18614,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
-  /read-pkg-up@1.0.1:
-    resolution: {integrity: sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      find-up: 1.1.2
-      read-pkg: 1.1.0
-    dev: false
-
   /read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
     engines: {node: '>=8'}
@@ -19111,15 +18622,6 @@ packages:
       read-pkg: 5.2.0
       type-fest: 0.8.1
     dev: true
-
-  /read-pkg@1.1.0:
-    resolution: {integrity: sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      load-json-file: 1.1.0
-      normalize-package-data: 2.5.0
-      path-type: 1.1.0
-    dev: false
 
   /read-pkg@5.2.0:
     resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
@@ -19247,10 +18749,6 @@ packages:
 
   /regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
-
-  /regenerator-runtime@0.10.5:
-    resolution: {integrity: sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==}
-    dev: false
 
   /regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -19493,10 +18991,6 @@ packages:
     resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
     dev: false
 
-  /require-main-filename@1.0.1:
-    resolution: {integrity: sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==}
-    dev: false
-
   /require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
@@ -19579,10 +19073,6 @@ packages:
   /ret@0.2.2:
     resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
     engines: {node: '>=4'}
-    dev: false
-
-  /retry@0.10.1:
-    resolution: {integrity: sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ==}
     dev: false
 
   /retry@0.13.1:
@@ -19826,13 +19316,6 @@ packages:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
-
-  /sentence-case@2.1.1:
-    resolution: {integrity: sha512-ENl7cYHaK/Ktwk5OTD+aDbQ3uC8IByu/6Bkg+HDv8Mm+XnBnppVNalcfJTNsp1ibstKh030/JKQQWglDvtKwEQ==}
-    dependencies:
-      no-case: 2.3.2
-      upper-case-first: 1.1.2
-    dev: false
 
   /sentence-case@3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
@@ -20129,12 +19612,6 @@ packages:
       is-fullwidth-code-point: 5.0.0
     dev: true
 
-  /snake-case@2.1.0:
-    resolution: {integrity: sha512-FMR5YoPFwOLuh4rRz92dywJjyKYZNLpMn1R5ujVpIYkbA9p01fq8RMg0FkO4M+Yobt4MjHeLTJVm5xFFBHSV2Q==}
-    dependencies:
-      no-case: 2.3.2
-    dev: false
-
   /snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
@@ -20164,12 +19641,6 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
-  /source-map-support@0.4.18:
-    resolution: {integrity: sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==}
-    dependencies:
-      source-map: 0.5.7
-    dev: false
-
   /source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
     dependencies:
@@ -20182,11 +19653,6 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-
-  /source-map@0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -20231,18 +19697,22 @@ packages:
     dependencies:
       spdx-expression-parse: 3.0.1
       spdx-license-ids: 3.0.16
+    dev: true
 
   /spdx-exceptions@2.4.0:
     resolution: {integrity: sha512-hcjppoJ68fhxA/cjbN4T8N6uCUejN8yFw69ttpqtBeCbF3u13n7mb31NB9jKwGTTWWnt9IbRA/mf1FprYS8wfw==}
+    dev: true
 
   /spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.4.0
       spdx-license-ids: 3.0.16
+    dev: true
 
   /spdx-license-ids@3.0.16:
     resolution: {integrity: sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==}
+    dev: true
 
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
@@ -20452,15 +19922,6 @@ packages:
       strip-ansi: 7.1.0
     dev: true
 
-  /string-width@1.0.2:
-    resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      code-point-at: 1.1.0
-      is-fullwidth-code-point: 1.0.0
-      strip-ansi: 3.0.1
-    dev: false
-
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -20512,13 +19973,6 @@ packages:
       is-regexp: 1.0.0
     dev: false
 
-  /strip-ansi@3.0.1:
-    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-regex: 2.1.1
-    dev: false
-
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -20534,13 +19988,6 @@ packages:
   /strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
-    dev: false
-
-  /strip-bom@2.0.0:
-    resolution: {integrity: sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-utf8: 0.2.1
     dev: false
 
   /strip-bom@3.0.0:
@@ -20697,13 +20144,6 @@ packages:
       yargs: 17.7.2
     transitivePeerDependencies:
       - encoding
-    dev: false
-
-  /swap-case@1.1.2:
-    resolution: {integrity: sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==}
-    dependencies:
-      lower-case: 1.1.4
-      upper-case: 1.1.3
     dev: false
 
   /swap-case@2.0.2:
@@ -20906,13 +20346,6 @@ packages:
   /tinyspy@2.2.0:
     resolution: {integrity: sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==}
     engines: {node: '>=14.0.0'}
-
-  /title-case@2.1.1:
-    resolution: {integrity: sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==}
-    dependencies:
-      no-case: 2.3.2
-      upper-case: 1.1.3
-    dev: false
 
   /title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
@@ -21557,20 +20990,10 @@ packages:
       xdg-basedir: 5.1.0
     dev: false
 
-  /upper-case-first@1.1.2:
-    resolution: {integrity: sha512-wINKYvI3Db8dtjikdAqoBbZoP6Q+PZUyfMR7pmwHzjC2quzSkUq5DmPrTtPEqHaz8AGtmsB4TqwapMTM1QAQOQ==}
-    dependencies:
-      upper-case: 1.1.3
-    dev: false
-
   /upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
       tslib: 2.6.2
-
-  /upper-case@1.1.3:
-    resolution: {integrity: sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==}
-    dev: false
 
   /upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
@@ -21653,13 +21076,6 @@ packages:
       react: 18.2.0
       tslib: 2.6.2
 
-  /user-home@2.0.0:
-    resolution: {integrity: sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      os-homedir: 1.0.2
-    dev: false
-
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -21730,6 +21146,7 @@ packages:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+    dev: true
 
   /value-equal@1.0.1:
     resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
@@ -22234,10 +21651,6 @@ packages:
       is-weakset: 2.0.2
     dev: true
 
-  /which-module@1.0.0:
-    resolution: {integrity: sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ==}
-    dev: false
-
   /which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
@@ -22285,14 +21698,6 @@ packages:
   /wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: true
-
-  /wrap-ansi@2.1.0:
-    resolution: {integrity: sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      string-width: 1.0.2
-      strip-ansi: 3.0.1
-    dev: false
 
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -22407,10 +21812,6 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  /y18n@3.2.2:
-    resolution: {integrity: sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==}
-    dev: false
-
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
@@ -22453,13 +21854,6 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
-  /yargs-parser@5.0.1:
-    resolution: {integrity: sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==}
-    dependencies:
-      camelcase: 3.0.0
-      object.assign: 4.1.5
-    dev: false
-
   /yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
@@ -22500,24 +21894,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  /yargs@7.1.2:
-    resolution: {integrity: sha512-ZEjj/dQYQy0Zx0lgLMLR8QuaqTihnxirir7EwUHp1Axq4e3+k8jXU5K0VLbNvedv1f4EWtBonDIZm0NUr+jCcA==}
-    dependencies:
-      camelcase: 3.0.0
-      cliui: 3.2.0
-      decamelize: 1.2.0
-      get-caller-file: 1.0.3
-      os-locale: 1.4.0
-      read-pkg-up: 1.0.1
-      require-directory: 2.1.1
-      require-main-filename: 1.0.1
-      set-blocking: 2.0.0
-      string-width: 1.0.2
-      which-module: 1.0.0
-      y18n: 3.2.2
-      yargs-parser: 5.0.1
-    dev: false
 
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}


### PR DESCRIPTION
Feat: Flervalgsstøtte i filter.

Refaktorer FilterBar component til et nivå hvor output kun representeres som `id` og `value`, som i kombinasjon med søkestreng, lagres. All tilleggsinformasjon er ikke nødvendig å lagre, og hentes ut ifra settings / andre props.

Var tvunget til å ta inn endringer i GQL schema fra Dialogporten pga endringer i backend.


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->