### PR TITLE
fix: remove filters with undefined as value

### DIFF
--- a/packages/frontend/src/pages/SavedSearches/SavedSearches.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearches.tsx
@@ -1,12 +1,12 @@
 import { SavedSearchesFieldsFragment, SavedSearchesQuery } from 'bff-types-generated';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from 'react-query';
 import { deleteSavedSearch, fetchSavedSearches } from '../../api/queries';
 import { useSnackbar } from '../../components/Snackbar/useSnackbar';
+import { EditSavedSearch } from './EditSearchesItem';
 import { SavedSearchesItem } from './SavedSearchesItem';
 import styles from './savedSearches.module.css';
-import { useState } from 'react';
-import { EditSavedSearch } from './EditSearchesItem';
 
 export const useSavedSearches = () => useQuery<SavedSearchesQuery, Error>('savedSearches', fetchSavedSearches);
 
@@ -94,12 +94,12 @@ export const SavedSearches = () => {
     if (!id) return;
 
     try {
-      await deleteSavedSearch(id)
+      await deleteSavedSearch(id);
       openSnackbar({
         message: t('savedSearches.deleted_success'),
         variant: 'success',
       });
-      queryClient.invalidateQueries('savedSearches');
+      await queryClient.invalidateQueries('savedSearches');
     } catch (error) {
       console.error('Failed to delete saved search:', error);
       openSnackbar({
@@ -112,15 +112,26 @@ export const SavedSearches = () => {
   return (
     <main>
       <section className={styles.savedSearchesWrapper}>
-        <EditSavedSearch key={selectedSavedSearch?.id} isOpen={!!selectedSavedSearch} savedSearch={selectedSavedSearch} onDelete={handleDeleteSearch} onClose={() => setSelectedSavedSearch(undefined)} />
+        <EditSavedSearch
+          key={selectedSavedSearch?.id}
+          isOpen={!!selectedSavedSearch}
+          savedSearch={selectedSavedSearch}
+          onDelete={handleDeleteSearch}
+          onClose={() => setSelectedSavedSearch(undefined)}
+        />
         <div className={styles.title}>{t('savedSearches.title', { count: savedSearches?.length || 0 })}</div>
-        {!!savedSearches?.length &&
+        {!!savedSearches?.length && (
           <div className={styles.savedSearchesContainer}>
             {savedSearches?.map((search) => (
-              <SavedSearchesItem key={search?.id} savedSearch={search} onDelete={handleDeleteSearch} setSelectedSavedSearch={setSelectedSavedSearch} />
+              <SavedSearchesItem
+                key={search?.id}
+                savedSearch={search}
+                onDelete={handleDeleteSearch}
+                setSelectedSavedSearch={setSelectedSavedSearch}
+              />
             ))}
           </div>
-        }
+        )}
         <LastUpdated searches={savedSearches} />
       </section>
     </main>

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
@@ -1,7 +1,7 @@
 import { DropdownMenu } from '@digdir/designsystemet-react';
 import { ChevronRightIcon, EllipsisHorizontalIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { PencilIcon } from '@navikt/aksel-icons';
-import { SavedSearchData, SavedSearchesFieldsFragment } from 'bff-types-generated';
+import { SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { useTranslation } from 'react-i18next';
 import { compressQueryParams } from '../Inbox/Inbox';
 import styles from './savedSearches.module.css';
@@ -46,7 +46,7 @@ const RenderButtons = ({ savedSearch, onDelete, setSelectedSavedSearch }: SavedS
 
 export const SavedSearchesItem = ({ savedSearch, onDelete, setSelectedSavedSearch }: SavedSearchesItemProps) => {
   if (!savedSearch?.data) return null;
-  const searchData = savedSearch.data as SavedSearchData;
+  const searchData = savedSearch.data;
 
   if (savedSearch.name)
     return (
@@ -63,6 +63,8 @@ export const SavedSearchesItem = ({ savedSearch, onDelete, setSelectedSavedSearc
       </>
     );
 
+  console.log(savedSearch);
+
   return (
     <>
       <div className={styles.savedSearchItem} key={savedSearch.id}>
@@ -72,7 +74,9 @@ export const SavedSearchesItem = ({ savedSearch, onDelete, setSelectedSavedSearc
           {searchData?.filters?.map((search, index) => {
             const id = search?.id;
             return (
-              <span key={`${id}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'} ${id}`}</span>
+              <span key={`${id}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'} ${
+                search?.value
+              }`}</span>
             );
           })}
         </div>


### PR DESCRIPTION
Fikser feil at filtre inneholder objekter som har verdi `undefined`, som intern i `FilterBar` brukes som placeholder-state for å angi at et filter er valgt, men ikke spesifisert. 

Og erstatter id med `value`:

Samlet fikser dette viewet for lagret søk:

![image](https://github.com/digdir/dialogporten-frontend/assets/3768832/ad36b23f-743d-4b89-b711-b2bb6df0cc20)


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->