### PR TITLE
feat: finalize-ish design for desktop and larger screens for FilterBar

### DIFF
--- a/packages/frontend/src/components/FilterBar/AddFilterButton/AddFilterButton.tsx
+++ b/packages/frontend/src/components/FilterBar/AddFilterButton/AddFilterButton.tsx
@@ -25,7 +25,14 @@ export const AddFilterButton = ({
   const { t } = useTranslation();
   return (
     <div>
-      <Button size="small" onClick={onAddBtnClick} disabled={disabled} variant="secondary" color="first">
+      <Button
+        size="small"
+        onClick={onAddBtnClick}
+        disabled={disabled}
+        variant="secondary"
+        color="first"
+        className={styles.addFilterButton}
+      >
         <PlusIcon /> {t('filter_bar.add_filter')}
       </Button>
       {isMenuOpen && (
@@ -39,12 +46,9 @@ export const AddFilterButton = ({
                 onClick={() => {
                   onListItemClick(setting.id, undefined);
                 }}
-              >
-                <div className={styles.addFilterButtonContent}>
-                  <span className={styles.addFilterItemLabel}>{setting.label}</span>
-                  <ChevronRightIcon fontSize="1.5rem" />
-                </div>
-              </FilterListItem>
+                leftContent={<span className={styles.addFilterItemLabel}>{setting.label}</span>}
+                rightContent={<ChevronRightIcon fontSize="1.5rem" />}
+              />
             );
           })}
         </FilterList>

--- a/packages/frontend/src/components/FilterBar/AddFilterButton/addFilterButton.module.css
+++ b/packages/frontend/src/components/FilterBar/AddFilterButton/addFilterButton.module.css
@@ -7,6 +7,10 @@
     z-index: 1001;
 }
 
+.addFilterButton {
+    white-space: nowrap;
+}
+
 .addFilterItemLabel {
     font-size: 1rem;
 }

--- a/packages/frontend/src/components/FilterBar/FilterBar.tsx
+++ b/packages/frontend/src/components/FilterBar/FilterBar.tsx
@@ -183,14 +183,14 @@ export const FilterBar = ({ onFilterChange, settings, initialFilters = [] }: Fil
             />
           );
         })}
+        <AddFilterButton
+          isMenuOpen={listOpenForTarget === 'add_filter'}
+          onAddBtnClick={() => setListOpenForTarget(listOpenForTarget === 'add_filter' ? 'none' : 'add_filter')}
+          settings={settings}
+          selectedFilters={selectedFilters}
+          onListItemClick={onToggleFilter}
+        />
       </div>
-      <AddFilterButton
-        isMenuOpen={listOpenForTarget === 'add_filter'}
-        onAddBtnClick={() => setListOpenForTarget(listOpenForTarget === 'add_filter' ? 'none' : 'add_filter')}
-        settings={settings}
-        selectedFilters={selectedFilters}
-        onListItemClick={onToggleFilter}
-      />
       <Backdrop show={listOpenForTarget !== 'none'} onClick={() => setListOpenForTarget('none')} />
     </section>
   );

--- a/packages/frontend/src/components/FilterBar/FilterButton/filterButton.module.css
+++ b/packages/frontend/src/components/FilterBar/FilterButton/filterButton.module.css
@@ -19,6 +19,12 @@
     column-gap: 1em;
 }
 
+.button {
+    white-space: nowrap;
+    background-color: var(--button-color);
+    color: var(--background-color);
+}
+
 .filterDateContent {
     min-width: 300px;
     display: flex;
@@ -27,21 +33,28 @@
     row-gap: 1rem;
 }
 
+.checkMarkHolder {
+    min-width: 1.5rem;
+    svg {
+        height: 1.5rem;
+        width: auto;
+    }
+}
+
 .filterListLabel {
     font-size: 1rem;
+    margin-left: 0.5rem;
 }
 
 .filterListCount {
-    padding: 0.5rem;
     font-size: 0.75rem;
     font-weight: 600;
-    line-height: 1.25;
-    border-radius: 50%;
-    height: 16px;
-    width: 16px;;
-    display: inline-flex;
-    align-items: center;
+    display: flex;
+    height: 24px;
+    min-width: 24px;
+    padding: 4px 8px;
     justify-content: center;
-    background-color: rgb(243, 244, 246);
-    color: #000;
+    align-items: center;
+    border-radius: 12px;
+    background: var(--black-5, rgba(0, 0, 0, 0.05));
 }

--- a/packages/frontend/src/components/FilterBar/FilterList/FilterListItem.tsx
+++ b/packages/frontend/src/components/FilterBar/FilterList/FilterListItem.tsx
@@ -2,10 +2,11 @@ import cx from 'classnames';
 import styles from './filterListItem.module.css';
 interface FilterListItemProps {
   onClick: () => void;
-  children?: React.ReactNode;
+  leftContent?: React.ReactNode;
+  rightContent?: React.ReactNode;
   disabled?: boolean;
 }
-export const FilterListItem = ({ children, onClick, disabled }: FilterListItemProps) => {
+export const FilterListItem = ({ leftContent, rightContent, onClick, disabled }: FilterListItemProps) => {
   const handleKeyUp = (event: React.KeyboardEvent<HTMLLIElement>) => {
     if (event.key === 'Enter' && !disabled) {
       onClick?.();
@@ -17,7 +18,10 @@ export const FilterListItem = ({ children, onClick, disabled }: FilterListItemPr
       className={cx(styles.filterListItem, { [styles.disabled]: disabled })}
       onKeyUp={disabled ? undefined : handleKeyUp}
     >
-      {children}
+      <div className={styles.content}>
+        <div className={styles.leftContent}>{leftContent}</div>
+        <div className={styles.rightContent}>{rightContent}</div>
+      </div>
     </li>
   );
 };

--- a/packages/frontend/src/components/FilterBar/FilterList/filterList.module.css
+++ b/packages/frontend/src/components/FilterBar/FilterList/filterList.module.css
@@ -1,10 +1,12 @@
 .filterList {
     list-style: none;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    border-radius: 0.375rem;
-    padding: 0.5rem 0;
+    border-radius: 6px;
+    padding: 0.5rem;
     position: absolute;
     z-index: 1001;
     background: #fff;
-    width: 350px;
+    min-width: 390px;
+    max-width: 390px;
+    margin-block-start: 10px;
 }

--- a/packages/frontend/src/components/FilterBar/FilterList/filterListItem.module.css
+++ b/packages/frontend/src/components/FilterBar/FilterList/filterListItem.module.css
@@ -1,12 +1,27 @@
 .filterListItem {
     cursor: pointer;
     &:hover:not(.disabled){
-        background: rgb(243, 244, 246);
+        background: var(--background-color);
     }
-    padding: 0.6rem 1rem;
+    padding: 0.375rem;
 }
 
 .disabled {
     opacity: 0.5;
     pointer-events: none;
+}
+
+.leftContent {
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+}
+
+.content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    column-gap: 1rem;
+    position: relative;
+    z-index: 1001;
+    font-weight: 500;
 }

--- a/packages/frontend/src/components/FilterBar/dateInfo.ts
+++ b/packages/frontend/src/components/FilterBar/dateInfo.ts
@@ -1,6 +1,10 @@
-import { Locale, nb } from 'date-fns/locale';
 import {
-  endOfDay, endOfMonth, endOfToday, endOfWeek, endOfYear, endOfYesterday,
+  endOfDay,
+  endOfMonth,
+  endOfToday,
+  endOfWeek,
+  endOfYear,
+  endOfYesterday,
   format,
   formatISO,
   parseISO,
@@ -9,11 +13,12 @@ import {
   startOfToday,
   startOfWeek,
   startOfYear,
-  startOfYesterday
+  startOfYesterday,
 } from 'date-fns';
-import { InboxItemInput } from "../../pages/Inbox/Inbox.tsx";
-import { CustomFilterValueType } from './FilterBar.tsx';
+import { Locale, nb } from 'date-fns/locale';
 import { t } from 'i18next';
+import { InboxItemInput } from '../../pages/Inbox/Inbox.tsx';
+import { CustomFilterValueType } from './FilterBar.tsx';
 
 interface CombinedDateInfo {
   isDate: boolean;
@@ -58,8 +63,7 @@ export const isCombinedDateAndInterval = (label: string, providedLocale?: Locale
     if (startMonth === endMonth) {
       if (startDay === endDay) {
         formattedLabel = `${startDay} ${startMonth} ${startYear}`;
-      }
-      else if (startYear === currentYear) {
+      } else if (startYear === currentYear) {
         formattedLabel = `${startDay}-${endDay} ${startMonth}`;
       } else if (startYear === endYear) {
         formattedLabel = `${startDay}-${endDay} ${startMonth} ${startYear}`;
@@ -78,7 +82,7 @@ export const isCombinedDateAndInterval = (label: string, providedLocale?: Locale
       isDate: true,
       label: formattedLabel,
       startDate,
-      endDate
+      endDate,
     };
   } catch (e) {
     return {
@@ -87,27 +91,28 @@ export const isCombinedDateAndInterval = (label: string, providedLocale?: Locale
   }
 };
 
-export const generateDateOptions = (dialogs: InboxItemInput[]) => {
-  const createdAt = dialogs.map((p) => parseISO(p.createdAt));
+export const getPredefinedRange = (): { range: string; label: string; value: string }[] => {
   const todayRange = `${formatISO(startOfToday())}/${formatISO(endOfToday())}`;
   const yesterdayRange = `${formatISO(startOfYesterday())}/${formatISO(endOfYesterday())}`;
   const thisWeekRange = `${formatISO(startOfWeek(new Date()))}/${formatISO(endOfWeek(new Date()))}`;
   const thisMonthRange = `${formatISO(startOfMonth(new Date()))}/${formatISO(endOfMonth(new Date()))}`;
   const thisYearRange = `${formatISO(startOfYear(new Date()))}/${formatISO(endOfYear(new Date()))}`;
+  return [
+    { label: t('filter_bar.range.today'), value: '$today', range: todayRange },
+    { label: t('filter_bar.range.yesterday'), value: '$yesterday', range: yesterdayRange },
+    { label: t('filter_bar.range.this_week'), value: '$thisWeek', range: thisWeekRange },
+    { label: t('filter_bar.range.this_month'), value: '$thisMonth', range: thisMonthRange },
+    { label: t('filter_bar.range.this_year'), value: '$thisYear', range: thisYearRange },
+  ];
+};
+export const generateDateOptions = (dialogs: InboxItemInput[]) => {
+  const createdAt = dialogs.map((p) => parseISO(p.createdAt));
   const firstDate = createdAt.sort((a, b) => a.getTime() - b.getTime())?.[0];
   const lastDate = createdAt.sort((a, b) => b.getTime() - a.getTime())?.[0];
 
-  const predefinedRanges = [
-    { label: t('filter_bar.range.today'), value: todayRange },
-    { label: t('filter_bar.range.yesterday'), value: yesterdayRange },
-    { label: t('filter_bar.range.this_week'), value: thisWeekRange },
-    { label: t('filter_bar.range.this_month'), value: thisMonthRange },
-    { label: t('filter_bar.range.this_year'), value: thisYearRange },
-  ];
-
-  const predefinedOptions =  predefinedRanges
-    .map(({ label, value }) => {
-      const { startDate, endDate } = isCombinedDateAndInterval(value);
+  const predefinedOptions = getPredefinedRange()
+    .map(({ label, value, range }) => {
+      const { startDate, endDate } = isCombinedDateAndInterval(range);
       const count = createdAt.filter((date) => date >= startDate! && date <= endDate!).length;
       return {
         displayLabel: label,
@@ -115,7 +120,7 @@ export const generateDateOptions = (dialogs: InboxItemInput[]) => {
         count,
       };
     })
-    .filter(option => option.count > 0);
+    .filter((option) => option.count > 0);
 
   if (firstDate && lastDate) {
     const customOption = {
@@ -128,7 +133,7 @@ export const generateDateOptions = (dialogs: InboxItemInput[]) => {
           displayLabel: t('filter_bar.range.custom'),
         },
       ],
-    }
+    };
     return [...predefinedOptions, customOption];
   }
   return predefinedOptions;
@@ -142,4 +147,4 @@ export const countOccurrences = (array: string[]): Record<string, number> => {
     },
     {} as Record<string, number>,
   );
-}
+};

--- a/packages/frontend/src/components/FilterBar/filterBar.module.css
+++ b/packages/frontend/src/components/FilterBar/filterBar.module.css
@@ -1,5 +1,6 @@
 .filterBar {
     display: flex;
+    flex-wrap: wrap;
     align-items: flex-start;
     column-gap: 1em;
     position: relative;
@@ -9,7 +10,9 @@
 .filterButtons {
     display: flex;
     align-items: flex-start;
+    flex-wrap: wrap;
     column-gap: 1em;
+    row-gap: 1em;
     position: relative;
     z-index: 1001;
 }

--- a/packages/frontend/src/components/Footer/footer.module.css
+++ b/packages/frontend/src/components/Footer/footer.module.css
@@ -29,8 +29,17 @@
     }
 
     li {
+        margin-top: 0.5rem;
         margin-bottom: 0.5rem;
     }
+}
+
+li {
+    margin-bottom: 0.5rem;
+}
+
+li:not(:first-child) {
+    margin-top: 0.5rem;
 }
 
 .content div {

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -3,6 +3,7 @@
   "example.your_inbox": "Din innboks",
   "dialog.status.in_progress": "Under arbeid",
   "dialog.status.new": "Nye",
+  "dialog.status.signing": "Til signering",
   "inbox.title": "Innboks",
   "inbox.attachment.count": "{count, plural, =0 {Ingen vedlegg} one {# vedlegg} other {# vedlegg}}",
   "inbox.attachment.link": "Lenke som vedlegg",
@@ -45,7 +46,9 @@
   "editSavedSearch.give_search_name": "Gi søket et navn",
   "editSavedSearch.search_without_name": "Søk uten navn",
   "sidebar.settings": "Innstillinger",
-  "filter_bar.add_filter": "Legg til",
+  "filter_bar_fields.to": "Til",
+  "filter_bar_fields.from": "Fra",
+  "filter_bar.add_filter": "Legg til filter",
   "filter_bar.save_search": "Lagre søk",
   "filter_bar.items_chosen": "{count, plural, =0 {Ingen valgt} one {# valgt} other {# valgt}}",
   "filter_bar.choose_date": "Bruk dato",
@@ -60,6 +63,7 @@
   "filter_bar.label.sender": "Avsender",
   "filter_bar.label.recipient": "Mottaker",
   "filter_bar.label.all_recipients": "Alle mottakere",
+  "filter_bar.label.all_senders": "Alle avsendere",
   "filter_bar.label.status": "Status",
   "filter_bar.label.all_statuses": "Alle statuser",
   "filter_bar.label.created": "Opprettet",
@@ -88,4 +92,3 @@
   "menuBar.chat": "Få hjelp på chat",
   "menuBar.chat.label": "Trykk her for å gå til chat"
 }
-

--- a/packages/frontend/src/pages/Inbox/inbox.module.css
+++ b/packages/frontend/src/pages/Inbox/inbox.module.css
@@ -7,6 +7,7 @@
 .filtersArea {
     display: flex;
     column-gap: 1rem;
+    row-gap: 1rem;
     flex-wrap: wrap;
     margin-bottom: 1rem;
 }

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
@@ -3,6 +3,7 @@ import { ChevronRightIcon, EllipsisHorizontalIcon, TrashIcon } from '@heroicons/
 import { PencilIcon } from '@navikt/aksel-icons';
 import { SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { useTranslation } from 'react-i18next';
+import { getPredefinedRange } from '../../components/FilterBar/dateInfo.ts';
 import { compressQueryParams } from '../Inbox/Inbox';
 import styles from './savedSearches.module.css';
 
@@ -19,7 +20,7 @@ const RenderButtons = ({ savedSearch, onDelete, setSelectedSavedSearch }: SavedS
     setSelectedSavedSearch?.(savedSearch);
   };
   return (
-    <div style={{ display: 'flex', alignItems: 'center' }}>
+    <div className={styles.renderButtons}>
       <DropdownMenu>
         <DropdownMenu.Trigger className={styles.linkButton}>
           <EllipsisHorizontalIcon className={styles.icon} />
@@ -70,10 +71,12 @@ export const SavedSearchesItem = ({ savedSearch, onDelete, setSelectedSavedSearc
           {searchData?.searchString && `${searchData.filters?.length ? ' + ' : ''}`}
           {searchData?.filters?.map((search, index) => {
             const id = search?.id;
+            const predefinedRange = getPredefinedRange().find((range) => range.value === search?.value);
+            const value = predefinedRange && search?.id === 'created' ? predefinedRange.label : search?.value;
             return (
-              <span key={`${id}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'} ${
-                search?.value
-              }`}</span>
+              <span key={`${id}${index}`} className={styles.filterElement}>{`${
+                index === 0 ? '' : ' +'
+              } ${value}`}</span>
             );
           })}
         </div>

--- a/packages/frontend/src/pages/SavedSearches/savedSearches.module.css
+++ b/packages/frontend/src/pages/SavedSearches/savedSearches.module.css
@@ -9,6 +9,11 @@
     border-radius: 0.5rem;
 }
 
+.renderButtons {
+    display: flex;
+    align-items: center;
+}
+
 .savedSearchItem {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Ferdigsstiller designet (tror jeg) for basisfunksjonalitet for desktop og større skjermer for FilterBar.

![image](https://github.com/digdir/dialogporten-frontend/assets/3768832/c1c89203-b091-4934-bdff-900d0aafbd46)

![image](https://github.com/digdir/dialogporten-frontend/assets/3768832/734c1d0d-23c1-4063-8a52-1e5a39c180df)

![image](https://github.com/digdir/dialogporten-frontend/assets/3768832/fea8c395-3219-4f09-b165-c9e61a5d0402)

Relative datoer (uker, dag, osv), er skrevet om slik at de alltid er relative i forhold til dagens dato ved senere bruk.


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->