### PR TITLE
fix:  broken linking and improved UX to no match routing

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,8 +1,7 @@
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import { PageLayout } from './components';
 import { Inbox } from './pages/Inbox';
 import { InboxItemPage } from './pages/InboxItemPage';
-import { PageNotFound } from './pages/PageNotFound';
 import { SavedSearches } from './pages/SavedSearches';
 
 import './app.css';
@@ -17,7 +16,7 @@ function App() {
           <Route path="/sent" element={<Inbox viewType={'sent'} />} />
           <Route path="/saved-searches" element={<SavedSearches />} />
           <Route path="/inbox/:id" element={<InboxItemPage />} />
-          <Route path="*" element={<PageNotFound />} />
+          <Route path="*" element={<Navigate to="/" />} />
         </Route>
         <Route
           path="/loggedout"

--- a/packages/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar/Sidebar.tsx
@@ -7,15 +7,15 @@ import {
   MagnifyingGlassIcon,
   TrashIcon,
 } from '@navikt/aksel-icons';
-import { SavedSearchesFieldsFragment } from 'bff-types-generated';
-import React from 'react';
+import type { SavedSearchesFieldsFragment } from 'bff-types-generated';
+import type React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useWindowSize } from '../../../utils/useWindowSize';
+import { useDialogs } from '../../api/useDialogs';
+import { useParties } from '../../api/useParties';
 import { useSavedSearches } from '../../pages/SavedSearches';
 import { SidebarItem } from './';
 import styles from './sidebar.module.css';
-import { useParties } from '../../api/useParties';
-import { useDialogs } from '../../api/useDialogs';
 
 export interface SidebarProps {
   children?: React.ReactNode;
@@ -44,8 +44,8 @@ export const Sidebar: React.FC<SidebarProps> = ({ children, isCompany }) => {
             displayText={t('sidebar.inbox')}
             label={t('sidebar.inbox.label')}
             icon={<InboxFillIcon />}
-            count={dialogsByView['inbox'].length}
-            path="/inbox"
+            count={dialogsByView.inbox.length}
+            path="/"
             isInbox
             isCompany={isCompany}
           />
@@ -54,7 +54,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ children, isCompany }) => {
             displayText={t('sidebar.drafts')}
             label={t('sidebar.drafts.label')}
             icon={<FileTextIcon />}
-            count={dialogsByView['draft'].length}
+            count={dialogsByView.draft.length}
             path="/drafts"
             isCompany={isCompany}
           />
@@ -62,7 +62,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ children, isCompany }) => {
             displayText={t('sidebar.sent')}
             label={t('sidebar.sent.label')}
             icon={<FileCheckmarkIcon />}
-            count={dialogsByView['sent'].length}
+            count={dialogsByView.sent.length}
             path="/sent"
             isCompany={isCompany}
           />

--- a/packages/frontend/src/pages/PageNotFound/PageNotFound.tsx
+++ b/packages/frontend/src/pages/PageNotFound/PageNotFound.tsx
@@ -1,7 +1,0 @@
-export const PageNotFound = () => {
-  return (
-    <main>
-      <h1>Ooops... page not found :(</h1>
-    </main>
-  );
-};

--- a/packages/frontend/src/pages/PageNotFound/index.ts
+++ b/packages/frontend/src/pages/PageNotFound/index.ts
@@ -1,1 +1,0 @@
-export { PageNotFound } from './PageNotFound.tsx';


### PR DESCRIPTION
Sidebar linket fremdeles til /inbox, som ikke lenger er en gyldig route.
Fjernet forstyrrende page not found-page for `no match`, med en redirect til `/` i stedet.


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->