### PR TITLE
feat: make Profilebutton loadable

### DIFF
--- a/packages/frontend/src/components/ProfileButton/ProfileButton.tsx
+++ b/packages/frontend/src/components/ProfileButton/ProfileButton.tsx
@@ -1,14 +1,34 @@
-import { Button, type ButtonProps } from '@digdir/designsystemet-react';
+import { Button, type ButtonProps, Spinner } from '@digdir/designsystemet-react';
 import cx from 'classnames';
 
+import { useTranslation } from 'react-i18next';
 import styles from './profileButton.module.css';
 
-export const ProfileButton = (props: ButtonProps) => {
-  const { className, variant = 'primary', ...restProps } = props;
+interface ProfileButtonProps extends ButtonProps {
+  isLoading?: boolean;
+}
+
+export const ProfileButton = (props: ProfileButtonProps) => {
+  const { t } = useTranslation();
+  const { className, isLoading, children, variant = 'primary', ...restProps } = props;
   const classes = cx(className, styles.profileButton, {
     [styles.primary]: variant === 'primary',
     [styles.secondary]: variant === 'secondary',
     [styles.tertiary]: variant === 'tertiary',
   });
-  return <Button className={classes} {...restProps} />;
+
+  if (isLoading) {
+    return (
+      <Button className={classes} {...restProps} aria-disabled>
+        <Spinner variant="interaction" title="loading" size="sm" />
+        {t('word.loading')}
+      </Button>
+    );
+  }
+
+  return (
+    <Button className={classes} {...restProps}>
+      {children}
+    </Button>
+  );
 };

--- a/packages/frontend/src/components/SavedSearchButton/SaveSearchButton.tsx
+++ b/packages/frontend/src/components/SavedSearchButton/SaveSearchButton.tsx
@@ -5,11 +5,12 @@ import { ProfileButton } from '../ProfileButton';
 
 type SaveSearchButtonProps = {
   onBtnClick: () => void;
+  isLoading?: boolean;
   disabled?: boolean;
 } & ButtonHTMLAttributes<HTMLButtonElement> &
   RefAttributes<HTMLButtonElement>;
 
-export const SaveSearchButton = ({ disabled, onBtnClick, className }: SaveSearchButtonProps) => {
+export const SaveSearchButton = ({ disabled, onBtnClick, className, isLoading }: SaveSearchButtonProps) => {
   const { t } = useTranslation();
 
   if (disabled) {
@@ -17,7 +18,7 @@ export const SaveSearchButton = ({ disabled, onBtnClick, className }: SaveSearch
   }
 
   return (
-    <ProfileButton size="small" className={className} onClick={onBtnClick} variant="secondary">
+    <ProfileButton size="small" className={className} onClick={onBtnClick} variant="secondary" isLoading={isLoading}>
       <BookmarkIcon fontSize="1.5rem" /> {t('filter_bar.save_search')}
     </ProfileButton>
   );

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -20,6 +20,7 @@
   "word.delete": "Slett",
   "word.seen": "Sett",
   "word.log_out": "Logg ut",
+  "word.loading": "Laster ...",
   "sidebar.inbox": "Innboks",
   "sidebar.inbox.label": "Trykk her for å gå til Innboks",
   "sidebar.drafts": "Under arbeid",

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -86,6 +86,7 @@ const getSortingOrderFromQueryParams = (searchParams: URLSearchParams): SortingO
 export const Inbox = ({ viewType }: InboxProps) => {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
+  const [isSavingSearch, setIsSavingSearch] = useState<boolean>(false);
   const [selectedSortOrder, setSelectedSortOrder] = useState<SortingOrder>('created_desc');
   const { selectedItems, setSelectedItems, selectedItemCount, inSelectionMode } = useSelectedDialogs();
   const location = useLocation();
@@ -128,6 +129,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
         filters: activeFilters as SearchDataValueFilter[],
         searchString,
       };
+      setIsSavingSearch(true);
       await createSavedSearch('', data);
       openSnackbar({
         message: t('savedSearches.saved_success'),
@@ -140,6 +142,8 @@ export const Inbox = ({ viewType }: InboxProps) => {
         variant: 'error',
       });
       console.error('Error creating saved search: ', error);
+    } finally {
+      setIsSavingSearch(false);
     }
   };
 
@@ -200,6 +204,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
               onBtnClick={handleSaveSearch}
               className={styles.hideForSmallScreens}
               disabled={savedSearchDisabled}
+              isLoading={isSavingSearch}
             />
           </div>
           <div className={styles.sortOrderContainer}>

--- a/packages/storybook/src/stories/ProfileButton/profileButton.stories.tsx
+++ b/packages/storybook/src/stories/ProfileButton/profileButton.stories.tsx
@@ -47,3 +47,7 @@ export const PersonSecondary = () => {
     </ProfileButton>
   );
 };
+
+export const LoadingButton = () => {
+  return <ProfileButton size="small" onClick={() => {}} variant="secondary" isLoading />;
+};


### PR DESCRIPTION
Utvider ProfileButton med loading state som kan brukes for operasjoner som er potensielt tidskrevende.
Eksemplifisert brukt med SavedSearch. 


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->