### PR TITLE
feat: cleanup code and make grouping of dialogs more flexible

### DIFF
--- a/packages/frontend/src/components/Header/SearchDropdown.tsx
+++ b/packages/frontend/src/components/Header/SearchDropdown.tsx
@@ -1,17 +1,17 @@
+import { ChevronRightIcon } from '@navikt/aksel-icons';
+import type { SavedSearchesFieldsFragment } from 'bff-types-generated';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
-import styles from './search.module.css';
-import { ChevronRightIcon } from '@navikt/aksel-icons';
-import { autoFormatRelativeTime, useSavedSearches } from '../../pages/SavedSearches';
-import { SavedSearchesFieldsFragment } from 'bff-types-generated';
-import { getPredefinedRange } from '../FilterBar/dateInfo';
-import { useParties } from '../../api/useParties';
 import { useSearchDialogs } from '../../api/useDialogs';
-import { InboxItem } from '../InboxItem';
-import { compressQueryParams } from '../../pages/Inbox/Inbox';
+import { useParties } from '../../api/useParties';
+import { compressQueryParams } from '../../pages/Inbox/queryParams.ts';
+import { autoFormatRelativeTime, useSavedSearches } from '../../pages/SavedSearches';
 import { Avatar } from '../Avatar';
+import { getPredefinedRange } from '../FilterBar/dateInfo';
+import { InboxItem } from '../InboxItem';
 import { SearchDropdownItem } from './SearchDropdownItem';
 import { SearchDropdownSkeleton } from './SearchDropdownSkeleton';
+import styles from './search.module.css';
 
 interface SearchDropdownProps {
   showDropdownMenu: boolean;
@@ -28,8 +28,8 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({ showDropdownMenu
   const { searchResults, isFetching } = useSearchDialogs({ parties, searchString: searchValue });
 
   const handleClose = () => {
-    onClose?.()
-  }
+    onClose?.();
+  };
 
   if (!showDropdownMenu) return null;
 
@@ -37,7 +37,10 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({ showDropdownMenu
     <div className={styles.menuItems}>
       <ul className={styles.menuList}>
         <SearchDropdownItem onClick={() => onSearch(searchValue)} horizontalLine>
-          <div className={styles.displayText}>{searchValue?.length > 2 ? <span className={styles.searchTermText}>{`«${searchValue}»`}</span> : 'Alt'} i innboks</div>
+          <div className={styles.displayText}>
+            {searchValue?.length > 2 ? <span className={styles.searchTermText}>{`«${searchValue}»`}</span> : 'Alt'} i
+            innboks
+          </div>
           <div className={styles.rightContent}>
             <span className={styles.keyText}>Return</span>
             <ChevronRightIcon className={styles.arrowIcon} />
@@ -45,59 +48,67 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({ showDropdownMenu
         </SearchDropdownItem>
 
         {/* Search results: */}
-        {isFetching ? <SearchDropdownSkeleton numberOfItems={3} /> : searchResults?.slice(0, 5).map((item) => (
-          <SearchDropdownItem key={item.id}>
-            <InboxItem
-              key={item.id}
-              checkboxValue={item.id}
-              title={item.title}
-              toLabel={t('word.to')}
-              description={item.description}
-              sender={item.sender}
-              receiver={item.receiver}
-              tags={item.tags}
-              linkTo={item.linkTo}
-              // Logic needed:
-              // isUnread={item.}
-              onClose={() => handleClose()}
-              isMinimalistic
-            />
-            <div className={cx(styles.rightContent)}>
-              <span className={styles.timeSince}>{autoFormatRelativeTime(new Date(item.date))}</span>
-              <Avatar name={item.sender.label} darkCircle type='small' />
-            </div>
-          </SearchDropdownItem>
-        ))}
-
-        {/* Saved searches: */}
-        {!searchResults?.length && <>
-          <SearchDropdownItem>
-            <div className={styles.displayText}>{t('sidebar.saved_searches')}</div>
-          </SearchDropdownItem>
-          {!isLoadingSavedSearches && savedSearches?.map((search) => (
-            <SearchDropdownItem key={search.id}>
-              <div className={styles.searchDetails}>
-                <span className={styles.searchString}>{search.data?.searchString && `«${search.data.searchString}»`}</span>
-                {search.data?.searchString && `${search.data.filters?.length ? ' + ' : ''}`}
-                {search.data?.filters?.map((search, index) => {
-                  const id = search?.id;
-                  const predefinedRange = getPredefinedRange().find((range) => range.value === search?.value);
-                  const value = predefinedRange && search?.id === 'created' ? predefinedRange.label : search?.value;
-                  return (
-                    <span key={`${id}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'
-                      } ${value}`}</span>
-                  );
-                })}
+        {isFetching ? (
+          <SearchDropdownSkeleton numberOfItems={3} />
+        ) : (
+          searchResults?.slice(0, 5).map((item) => (
+            <SearchDropdownItem key={item.id}>
+              <InboxItem
+                key={item.id}
+                checkboxValue={item.id}
+                title={item.title}
+                toLabel={t('word.to')}
+                description={item.description}
+                sender={item.sender}
+                receiver={item.receiver}
+                tags={item.tags}
+                linkTo={item.linkTo}
+                // Logic needed:
+                // isUnread={item.}
+                onClose={() => handleClose()}
+                isMinimalistic
+              />
+              <div className={cx(styles.rightContent)}>
+                <span className={styles.timeSince}>{autoFormatRelativeTime(new Date(item.date))}</span>
+                <Avatar name={item.sender.label} darkCircle type="small" />
               </div>
-              <a href={`inbox?data=${compressQueryParams(search.data)}`} onClick={() => handleClose()}>
-                <ChevronRightIcon className={styles.arrowIcon} />
-              </a>
             </SearchDropdownItem>
           ))
-          }
-        </>}
+        )}
+
+        {/* Saved searches: */}
+        {!searchResults?.length && (
+          <>
+            <SearchDropdownItem>
+              <div className={styles.displayText}>{t('sidebar.saved_searches')}</div>
+            </SearchDropdownItem>
+            {!isLoadingSavedSearches &&
+              savedSearches?.map((search) => (
+                <SearchDropdownItem key={search.id}>
+                  <div className={styles.searchDetails}>
+                    <span className={styles.searchString}>
+                      {search.data?.searchString && `«${search.data.searchString}»`}
+                    </span>
+                    {search.data?.searchString && `${search.data.filters?.length ? ' + ' : ''}`}
+                    {search.data?.filters?.map((search, index) => {
+                      const id = search?.id;
+                      const predefinedRange = getPredefinedRange().find((range) => range.value === search?.value);
+                      const value = predefinedRange && search?.id === 'created' ? predefinedRange.label : search?.value;
+                      return (
+                        <span key={`${id}${index}`} className={styles.filterElement}>{`${
+                          index === 0 ? '' : ' +'
+                        } ${value}`}</span>
+                      );
+                    })}
+                  </div>
+                  <a href={`inbox?data=${compressQueryParams(search.data)}`} onClick={() => handleClose()}>
+                    <ChevronRightIcon className={styles.arrowIcon} />
+                  </a>
+                </SearchDropdownItem>
+              ))}
+          </>
+        )}
       </ul>
     </div>
-  )
+  );
 };
-

--- a/packages/frontend/src/components/InboxItem/inboxItemsHeader.module.css
+++ b/packages/frontend/src/components/InboxItem/inboxItemsHeader.module.css
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    text-transform: capitalize;
     align-items: center;
     padding: 0 1rem;
 }

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -7,7 +7,7 @@ import { Footer, Header, Sidebar } from '..';
 import { useDialogs } from '../../api/useDialogs.tsx';
 import { useParties } from '../../api/useParties.ts';
 import { useAuthenticated } from '../../auth';
-import { decompressQueryParams } from '../../pages/Inbox/Inbox';
+import { decompressQueryParams } from '../../pages/Inbox/queryParams.ts';
 import { BottomDrawerContainer } from '../BottomDrawer';
 import { Snackbar } from '../Snackbar';
 import { SelectedDialogsContainer, useSelectedDialogs } from './SelectedDialogs.tsx';

--- a/packages/frontend/src/components/SortOrderDropdown/SortOrderDropdown.tsx
+++ b/packages/frontend/src/components/SortOrderDropdown/SortOrderDropdown.tsx
@@ -1,5 +1,6 @@
 import { ArrowsUpDownIcon, CheckmarkIcon, ChevronDownIcon } from '@navikt/aksel-icons';
 import cx from 'classnames';
+import { t } from 'i18next';
 import { type ForwardedRef, forwardRef, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Backdrop } from '../Backdrop';
@@ -20,23 +21,35 @@ interface SortOrderDropdownOption {
 interface SortOrderDropdownProps {
   onSelect: (selectedSortOrder: SortingOrder) => void;
   selectedSortOrder: SortingOrder;
-  options: SortOrderDropdownOption[];
+  options?: SortOrderDropdownOption[];
   btnClassName?: string;
 }
+
+const defaultSortOrderOptions = [
+  {
+    id: 'created_desc' as SortingOrder,
+    label: t('sort_order.created_desc'),
+  },
+  {
+    id: 'created_asc' as SortingOrder,
+    label: t('sort_order.created_asc'),
+  },
+];
+
 export const SortOrderDropdown = forwardRef(
   (
-    { onSelect, selectedSortOrder, options, btnClassName }: SortOrderDropdownProps,
+    { onSelect, selectedSortOrder, options = defaultSortOrderOptions, btnClassName }: SortOrderDropdownProps,
     ref: ForwardedRef<SortOrderDropdownRef>,
   ): JSX.Element => {
-    const [isOpen, setIsOpen] = useState<boolean>(false);
-    const { t } = useTranslation();
-    const selectedOptionLabel = options.find((option) => option.id === selectedSortOrder)?.label;
-
     useImperativeHandle(ref, () => ({
       openSortOrder() {
         setIsOpen(true);
       },
     }));
+
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+    const { t } = useTranslation();
+    const selectedOptionLabel = options.find((option) => option.id === selectedSortOrder)?.label;
 
     return (
       <div className={cx({ [styles.isOpen]: isOpen })}>

--- a/packages/frontend/src/pages/Inbox/queryParams.ts
+++ b/packages/frontend/src/pages/Inbox/queryParams.ts
@@ -1,0 +1,34 @@
+import type { SavedSearchData } from 'bff-types-generated';
+import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
+import type { Filter } from '../../components';
+import type { SortingOrder } from '../../components/SortOrderDropdown/SortOrderDropdown.tsx';
+
+export const compressQueryParams = (params: SavedSearchData): string => {
+  const queryParamsString = JSON.stringify(params);
+  return compressToEncodedURIComponent(queryParamsString);
+};
+
+export const decompressQueryParams = (compressedString: string): SavedSearchData => {
+  const decompressedString = decompressFromEncodedURIComponent(compressedString);
+  if (!decompressedString) {
+    throw new Error('Decompression failed');
+  }
+  return JSON.parse(decompressedString);
+};
+
+export const getFiltersFromQueryParams = (searchParams: URLSearchParams): Filter[] => {
+  const compressedData = searchParams.get('data');
+  if (compressedData) {
+    try {
+      const queryParams = decompressQueryParams(compressedData);
+      return queryParams.filters as Filter[];
+    } catch (error) {
+      console.error('Failed to decompress query parameters:', error);
+    }
+  }
+  return [] as Filter[];
+};
+
+export const getSortingOrderFromQueryParams = (searchParams: URLSearchParams): SortingOrder => {
+  return searchParams.get('sortBy') as SortingOrder;
+};

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
@@ -4,7 +4,7 @@ import { PencilIcon } from '@navikt/aksel-icons';
 import type { SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { useTranslation } from 'react-i18next';
 import { getPredefinedRange } from '../../components/FilterBar/dateInfo.ts';
-import { compressQueryParams } from '../Inbox/Inbox';
+import { compressQueryParams } from '../Inbox/queryParams.ts';
 import styles from './savedSearches.module.css';
 
 interface SavedSearchesItemProps {
@@ -74,8 +74,9 @@ export const SavedSearchesItem = ({ savedSearch, onDelete, setSelectedSavedSearc
             const predefinedRange = getPredefinedRange().find((range) => range.value === search?.value);
             const value = predefinedRange && search?.id === 'created' ? predefinedRange.label : search?.value;
             return (
-              <span key={`${id}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'
-                } ${value}`}</span>
+              <span key={`${id}${index}`} className={styles.filterElement}>{`${
+                index === 0 ? '' : ' +'
+              } ${value}`}</span>
             );
           })}
         </div>


### PR DESCRIPTION
- Forandrer interface for gruppering av dialoger for å kunne sortere gruppene kronologisk og kople mer metadata til gruppeinformasjonen. Før var det kun én key.  
- Rydder litt opp i Inbox.tsx

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->