### PR TITLE
feat(frontend): move header and footer out of the grid

### DIFF
--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -7,12 +7,12 @@ import { Footer, Header, Sidebar } from '..';
 import { useDialogs } from '../../api/useDialogs.tsx';
 import { useParties } from '../../api/useParties.ts';
 import { useAuthenticated } from '../../auth';
+import { getSearchStringFromQueryParams } from '../../pages/Inbox/queryParams.ts';
+import { useProfile } from '../../profile/useProfile';
 import { BottomDrawerContainer } from '../BottomDrawer';
 import { Snackbar } from '../Snackbar';
 import { SelectedDialogsContainer, useSelectedDialogs } from './SelectedDialogs.tsx';
-import { useProfile } from '../../profile/useProfile';
 import styles from './pageLayout.module.css';
-import { getSearchStringFromQueryParams } from '../../pages/Inbox/queryParams.ts';
 
 export const useUpdateOnLocationChange = (fn: () => void) => {
   const location = useLocation();
@@ -33,12 +33,14 @@ const PageLayoutContent: React.FC<PageLayoutContentProps> = memo(
     const { inSelectionMode } = useSelectedDialogs();
 
     return (
-      <div className={styles.pageLayout}>
+      <>
         <Header name={name} companyName={companyName} notificationCount={notificationCount} />
-        {!inSelectionMode && <Sidebar isCompany={isCompany} />}
-        <Outlet />
+        <div className={styles.pageLayout}>
+          {!inSelectionMode && <Sidebar isCompany={isCompany} />}
+          <Outlet />
+        </div>
         <Footer />
-      </div>
+      </>
     );
   },
 );

--- a/packages/frontend/src/components/PageLayout/pageLayout.module.css
+++ b/packages/frontend/src/components/PageLayout/pageLayout.module.css
@@ -1,19 +1,13 @@
 .pageLayout {
   display: grid;
-  grid-template-areas:
-    "header header header"
-    "main main main"
-    "footer footer footer";
+  grid-template-areas: "main main";
   grid-template-columns: 1fr 3fr;
   grid-template-rows: auto 1fr auto;
   max-width: 1920px;
   margin: 0 auto;
 
   @media (min-width: 600px) {
-    grid-template-areas:
-      "header header header"
-      "sidebar main main"
-      "footer footer footer";
+    grid-template-areas: "sidebar main";
     grid-template-columns: 1fr 3fr;
   }
 }


### PR DESCRIPTION
In the design header and footer takes up the whole width of the screen and are not a part of a grid.

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

![Screenshot 2024-06-28 at 13 47 20](https://github.com/digdir/dialogporten-frontend/assets/213777/4fad633e-8c95-45d6-bd47-53a9f9e4485d)
