### PR TITLE
chore: remove "status" field from Docker compose files

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 include:
   - path:
       - ./oidc-mock/oidc-mock.compose.yml

--- a/oidc-mock/oidc-mock.compose.yml
+++ b/oidc-mock/oidc-mock.compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   oidc-mock:
     container_name: oidc-mock


### PR DESCRIPTION
When starting up Docker Compose they warn that the "version" field is no longer needed.

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->