### PR TITLE
fix: mainContentReference is nullable

### DIFF
--- a/packages/frontend/src/api/useDialogById.tsx
+++ b/packages/frontend/src/api/useDialogById.tsx
@@ -82,9 +82,9 @@ const getTags = (item: DialogByIdFieldsFragment, format: FormatFunction): { labe
 };
 
 const getMainContentReference = (
-  args: { value: ValueType; mediaType: string } | undefined,
+  args: { value: ValueType; mediaType: string } | undefined | null,
 ): MainContentReference | undefined => {
-  if (typeof args === 'undefined') return undefined;
+  if (typeof args === 'undefined' || args === null) return undefined;
 
   const { value, mediaType } = args;
   const url = getPropertyByCultureCode(value);
@@ -110,7 +110,7 @@ export function mapDialogDtoToInboxItem(
   const titleObj = item?.content?.title?.value;
   const additionalInfoObj = item?.content?.additionalInfo?.value;
   const summaryObj = item?.content?.summary?.value;
-  const mainContentReference = item?.content?.mainContentReference!;
+  const mainContentReference = item?.content?.mainContentReference;
   const nameOfParty = parties?.find((party) => party.party === item.party)?.name ?? '';
   const serviceOwner = getOrganisation(item.org, 'nb');
   return {


### PR DESCRIPTION
Inboxdetaljer ville ikke vises fordi `mainContentReference` (som har mange innslag av `null` i dataene) ikke ble behandlet som `nullable`.

Lukker #861 

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->