### PR TITLE
fix(frontend): design fixes on saved search

### DIFF
--- a/packages/frontend/src/components/Backdrop/Modal.tsx
+++ b/packages/frontend/src/components/Backdrop/Modal.tsx
@@ -1,0 +1,31 @@
+import { Modal } from '@digdir/designsystemet-react';
+import type React from 'react';
+import { Backdrop } from '.';
+import styles from './backdrop.module.css';
+
+type ModalProps = Parameters<typeof Modal>[0];
+
+type Props = {
+  open: boolean;
+  children?: React.ReactChild | React.ReactChild[];
+} & ModalProps;
+
+/*
+ *  Wrapper component that adds a backdrop and fixes z-index
+ */
+export const ModalWithBackdrop = ({ children, open, ...props }: Props) => {
+  const onClose = () => {
+    if (typeof props.onClose === 'function') {
+      props.onClose();
+    }
+  };
+
+  return (
+    <>
+      <Modal open={open} className={styles.zIndexFix} {...props}>
+        {children}
+      </Modal>
+      <Backdrop show={open} onClick={onClose} />
+    </>
+  );
+};

--- a/packages/frontend/src/components/Backdrop/backdrop.module.css
+++ b/packages/frontend/src/components/Backdrop/backdrop.module.css
@@ -8,3 +8,7 @@
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   z-index: 10;
 }
+
+.zIndexFix {
+  z-index: 110;
+}

--- a/packages/frontend/src/components/Backdrop/index.ts
+++ b/packages/frontend/src/components/Backdrop/index.ts
@@ -1,1 +1,2 @@
 export { Backdrop } from './Backdrop.tsx';
+export { ModalWithBackdrop } from './Modal.tsx';

--- a/packages/frontend/src/pages/SavedSearches/EditSearchesItem.tsx
+++ b/packages/frontend/src/pages/SavedSearches/EditSearchesItem.tsx
@@ -1,10 +1,12 @@
 import { Button, Modal } from '@digdir/designsystemet-react';
+import { TrashIcon } from '@heroicons/react/24/outline';
 import type { SavedSearchData, SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import { autoFormatRelativeTime } from '.';
 import { updateSavedSearch } from '../../api/queries';
+import { ModalWithBackdrop } from '../../components/Backdrop';
 import { useSnackbar } from '../../components/Snackbar/useSnackbar';
 import { useFormatDistance } from '../../i18n/useDateFnsLocale.tsx';
 import styles from './savedSearches.module.css';
@@ -42,53 +44,47 @@ export const EditSavedSearch = ({ savedSearch, onDelete, onClose, isOpen }: Edit
   if (!isOpen || !savedSearch?.id) return null;
 
   return (
-    <div className={styles.editSavedSearch}>
-      <Modal
-        onInteractOutside={() => console.log('Interact outside')} // NEEDS TO BE FIXED
-        onBeforeClose={onClose}
-        open={isOpen}
-        onClose={onClose}
-      >
-        <Modal.Header className={styles.editSavedSearchHeader}>
-          <div className={styles.searchDetails}>
-            <span className={styles.searchString}>{searchData?.searchString && `«${searchData.searchString}»`}</span>
-            {searchData?.searchString && `${searchData.filters?.length ? ' + ' : ''}`}
-            {searchData?.filters?.map((search, index) => {
-              const id = search?.id;
-              return (
-                <span key={`${id}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'} ${id}`}</span>
-              );
-            })}
-          </div>
-        </Modal.Header>
-        <Modal.Content>
-          <hr className={styles.horizontalLine} />
-          <div className={styles.searchFormBody}>
-            <label htmlFor="searchName">{t('editSavedSearch.give_search_name')}</label>
-            <input
-              id="searchName"
-              type="text"
-              placeholder={t('editSavedSearch.search_without_name')}
-              value={searchName}
-              onChange={handleSearchNameChange}
-            />
-          </div>
-        </Modal.Content>
-        <Modal.Footer>
-          <div className={styles.searchFormFooter}>
-            <Button className={styles.saveButton} onClick={handleSave}>
-              {t('editSavedSearch.save_and_close')}
-            </Button>
-            <Button variant="secondary" className={styles.deleteButton} onClick={() => onDelete?.(savedSearch)}>
-              {t('word.delete')}
-            </Button>
-            <span className={styles.updateTime}>
-              {t('savedSearches.lastUpdated')}
-              {autoFormatRelativeTime(new Date(Number.parseInt(savedSearch?.updatedAt, 10)), formatDistance)}
-            </span>
-          </div>
-        </Modal.Footer>
-      </Modal>
-    </div>
+    <ModalWithBackdrop onBeforeClose={onClose} open={isOpen} onClose={onClose}>
+      <Modal.Header className={styles.editSavedSearchHeader}>
+        <div className={styles.searchDetails}>
+          <span className={styles.searchString}>{searchData?.searchString && `«${searchData.searchString}»`}</span>
+          {searchData?.searchString && `${searchData.filters?.length ? ' + ' : ''}`}
+          {searchData?.filters?.map((search, index) => {
+            const id = search?.id;
+            return (
+              <span key={`${id}${index}`} className={styles.filterElement}>{`${index === 0 ? '' : ' +'} ${id}`}</span>
+            );
+          })}
+        </div>
+      </Modal.Header>
+      <Modal.Content>
+        <hr className={styles.horizontalLine} />
+        <div className={styles.searchFormBody}>
+          <label htmlFor="searchName">{t('editSavedSearch.give_search_name')}</label>
+          <input
+            id="searchName"
+            type="text"
+            placeholder={t('editSavedSearch.search_without_name')}
+            value={searchName}
+            onChange={handleSearchNameChange}
+          />
+        </div>
+      </Modal.Content>
+      <Modal.Footer>
+        <div className={styles.searchFormFooter}>
+          <Button className={styles.saveButton} onClick={handleSave}>
+            {t('editSavedSearch.save_and_close')}
+          </Button>
+          <Button variant="secondary" className={styles.deleteButton} onClick={() => onDelete?.(savedSearch)}>
+            <TrashIcon className={styles.icon} aria-hidden="true" />
+            <span>{t('word.delete')}</span>
+          </Button>
+          <span className={styles.updateTime}>
+            {t('savedSearches.lastUpdated')}
+            {autoFormatRelativeTime(new Date(Number.parseInt(savedSearch?.updatedAt, 10)), formatDistance)}
+          </span>
+        </div>
+      </Modal.Footer>
+    </ModalWithBackdrop>
   );
 };

--- a/packages/frontend/src/pages/SavedSearches/SavedSearches.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearches.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from 'react-query';
 import { deleteSavedSearch, fetchSavedSearches } from '../../api/queries';
+import { ModalWithBackdrop } from '../../components/Backdrop';
 import { useSnackbar } from '../../components/Snackbar/useSnackbar';
 import { type FormatDistanceFunction, useFormatDistance } from '../../i18n/useDateFnsLocale.tsx';
 import { EditSavedSearch } from './EditSearchesItem';
@@ -14,7 +15,7 @@ import styles from './savedSearches.module.css';
 interface DeleteSearchConfirmationProps {
   savedSearch: SavedSearchesFieldsFragment | false;
   onClose?: () => void;
-  isOpen?: boolean;
+  isOpen: boolean;
 }
 
 const DeleteSearchConfirmation = ({ savedSearch, onClose, isOpen }: DeleteSearchConfirmationProps) => {
@@ -44,7 +45,7 @@ const DeleteSearchConfirmation = ({ savedSearch, onClose, isOpen }: DeleteSearch
   };
 
   return (
-    <Modal onBeforeClose={onClose} open={isOpen} onClose={onClose}>
+    <ModalWithBackdrop onBeforeClose={onClose} open={isOpen} onClose={onClose}>
       <Modal.Header className={styles.editSavedSearchHeader}>Bekreft sletting</Modal.Header>
       <Modal.Content>
         <hr className={styles.horizontalLine} />
@@ -55,7 +56,7 @@ const DeleteSearchConfirmation = ({ savedSearch, onClose, isOpen }: DeleteSearch
           {t('word.delete')}
         </Button>
       </Modal.Footer>
-    </Modal>
+    </ModalWithBackdrop>
   );
 };
 

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
@@ -2,7 +2,9 @@ import { DropdownMenu } from '@digdir/designsystemet-react';
 import { ChevronRightIcon, EllipsisHorizontalIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { PencilIcon } from '@navikt/aksel-icons';
 import type { SavedSearchesFieldsFragment } from 'bff-types-generated';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Backdrop } from '../../components/Backdrop';
 import { getPredefinedRange } from '../../components/FilterBar/dateInfo.ts';
 import styles from './savedSearches.module.css';
 
@@ -31,6 +33,8 @@ export const OpenSavedSearchLink = ({ savedSearch, onClick }: OpenSavedSearchLin
 
 const RenderButtons = ({ savedSearch, onDelete, setSelectedSavedSearch }: SavedSearchesItemProps) => {
   const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
   if (!savedSearch?.data) return null;
 
   const handleOpenEditModal = () => {
@@ -39,23 +43,31 @@ const RenderButtons = ({ savedSearch, onDelete, setSelectedSavedSearch }: SavedS
 
   return (
     <div className={styles.renderButtons}>
-      <DropdownMenu>
-        <DropdownMenu.Trigger className={styles.linkButton}>
+      <DropdownMenu open={open} onClose={() => setOpen(false)}>
+        <DropdownMenu.Trigger className={styles.linkButton} onClick={() => setOpen(!open)}>
           <EllipsisHorizontalIcon className={styles.icon} />
         </DropdownMenu.Trigger>
-        <DropdownMenu.Content>
+        <DropdownMenu.Content className={styles.dropdownContent}>
           <DropdownMenu.Group>
             <DropdownMenu.Item onClick={handleOpenEditModal}>
-              <PencilIcon fontSize="1.5rem" aria-hidden="true" /> {t('savedSearches.change_name')}
+              <div className={styles.dropdownEditSearch}>
+                <PencilIcon fontSize="1.5rem" aria-hidden="true" />
+                <span>{t('savedSearches.change_name')}</span>
+                <ChevronRightIcon className={styles.icon} />
+              </div>
             </DropdownMenu.Item>
+            <hr />
             <DropdownMenu.Item onClick={() => onDelete?.(savedSearch)}>
-              <TrashIcon className={styles.icon} aria-hidden="true" />
-              {t('savedSearches.delete_search')}
+              <div className={styles.dropdownEditSearch}>
+                <TrashIcon className={styles.icon} aria-hidden="true" />
+                <span>{t('savedSearches.delete_search')}</span>
+              </div>
             </DropdownMenu.Item>
           </DropdownMenu.Group>
         </DropdownMenu.Content>
       </DropdownMenu>
       <OpenSavedSearchLink savedSearch={savedSearch} />
+      <Backdrop show={open} onClick={() => {}} />
     </div>
   );
 };

--- a/packages/frontend/src/pages/SavedSearches/savedSearches.module.css
+++ b/packages/frontend/src/pages/SavedSearches/savedSearches.module.css
@@ -32,10 +32,6 @@ hr:last-child {
   justify-content: space-between;
 }
 
-.editSavedSearch {
-  z-index: 999;
-}
-
 .title {
   color: #000;
   font-weight: 500;
@@ -115,6 +111,10 @@ hr:last-child {
 
 .searchFormBody {
   margin-bottom: 16px;
+
+  input {
+    box-sizing: border-box;
+  }
 }
 
 .searchFormBody label {
@@ -142,8 +142,8 @@ hr:last-child {
 }
 
 .searchFormFooter {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto auto auto;
   align-items: center;
 }
 
@@ -158,6 +158,9 @@ hr:last-child {
   font-style: normal;
   font-weight: 400;
   line-height: 1.5;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .horizontalLine {
@@ -165,4 +168,33 @@ hr:last-child {
   height: 1px;
   background-color: #00000040;
   margin-bottom: 1rem;
+}
+
+.dropdownContent {
+  border-radius: 0;
+
+  li {
+    margin: 0;
+  }
+
+  button {
+    border-radius: 2px;
+    padding: 0;
+    height: auto;
+  }
+
+  .dropdownEditSearch {
+    width: 100%;
+    display: grid;
+    grid-template-columns: min-content auto min-content;
+    align-items: start;
+    text-align: left;
+    gap: 6px;
+    padding: 6px;
+
+    & > svg,
+    & > span {
+      padding: 4px;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #839

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
- Ny ModalWithBakcdrop komponent som wrapper Designsystemet sin modal og legger med vår Backdrop. Så vidt jeg kan se så har alle skisser backdrop når det er modaler.

- Mye paddings og margins som fikses

- Noen ekstra ikoner hvor det manglet
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

![Screenshot 2024-07-30 at 12 48 56](https://github.com/user-attachments/assets/35cb033a-0c7b-4990-9ffa-2df05367a6d6)
_Backdrop, ikoner, padding_

![Screenshot 2024-07-30 at 12 49 11](https://github.com/user-attachments/assets/e4730688-8562-4988-b5ec-100c7ab7b47c)
_Backdrop, ikon på slette knapp_
