### PR TITLE
fix: adjustments to layout for desktop for inbox details

### DIFF
--- a/packages/frontend/src/components/InboxItem/inboxItemDetail.module.css
+++ b/packages/frontend/src/components/InboxItem/inboxItemDetail.module.css
@@ -1,11 +1,12 @@
 .inboxItemDetail {
   display: flex;
   flex-direction: column;
-  margin-top: 1rem;
   background: #fff;
+  padding: 1.5rem;
 }
 
 .descriptionContainer {
+  margin-left: 1rem;
   padding: 0 1.0625rem 1.0625rem;
   border-left: 4px solid rgba(0, 0, 0, 0.1);
   margin-top: 1rem;
@@ -66,15 +67,15 @@
 
 .participantIcon {
   margin-right: 0.375em;
-  height: 40px;
-  width: 40px;
+  height: 36px;
+  width: 36px;
   flex-shrink: 0;
   > svg,
   img {
     min-width: 100%;
     min-height: 100%;
-    max-width: 40px;
-    max-height: 40px;
+    max-width: 36px;
+    max-height: 36px;
   }
 }
 

--- a/packages/frontend/src/components/PageLayout/pageLayout.module.css
+++ b/packages/frontend/src/components/PageLayout/pageLayout.module.css
@@ -43,6 +43,6 @@
 
   .pageLayout > main {
     margin-right: 192px;
-    padding-top: 1.5rem;
+    margin-top: 1.5rem;
   }
 }

--- a/packages/frontend/src/pages/InboxItemPage/InboxItemPage.tsx
+++ b/packages/frontend/src/pages/InboxItemPage/InboxItemPage.tsx
@@ -27,10 +27,12 @@ export const InboxItemPage = () => {
 
   return (
     <main className={styles.itemInboxPage}>
-      <nav>
-        <BackButton pathTo="/inbox/" />
-      </nav>
-      <InboxItemDetail dialog={dialog} />
+      <section className={styles.itemInboxPageContent}>
+        <nav className={styles.itemInboxNav}>
+          <BackButton pathTo="/inbox/" />
+        </nav>
+        <InboxItemDetail dialog={dialog} />
+      </section>
     </main>
   );
 };

--- a/packages/frontend/src/pages/InboxItemPage/inboxItemPage.module.css
+++ b/packages/frontend/src/pages/InboxItemPage/inboxItemPage.module.css
@@ -2,4 +2,18 @@
   display: flex;
   flex-direction: column;
   background: #fff;
+
+  @media screen and (min-width: 600px) {
+    min-width: 550px;
+    max-width: 988px;
+  }
+}
+
+.itemInboxPageContent {
+  padding: 0.5rem;
+}
+
+.itemInboxNav {
+  display: flex;
+  align-items: center;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d638ddf7-994e-4b1a-921f-b71ad74ab09b)

Ordner marginer og størrelser for hovedramme for inbox-detaljer.

Egen PR for mobil / pad. Egne oppgaver for innhold i visningen, som f.eks. gui-knapper og transmissions.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->