### PR TITLE
feat: make gui action buttons work for all http methods

### DIFF
--- a/packages/bff-types-generated/queries/dialog.fragment.graphql
+++ b/packages/bff-types-generated/queries/dialog.fragment.graphql
@@ -40,6 +40,7 @@ fragment SearchDialogFields on SearchDialog {
 
 fragment DialogByIdFields on Dialog {
   id
+  dialogToken
   party
   org
   progress
@@ -82,16 +83,22 @@ fragment DialogByIdFields on Dialog {
 }
 
 fragment GuiActionFields on GuiAction {
-    id
-    action
-    url
-    isAuthorized
-    httpMethod
-    title {
-       value
-       languageCode
-    }
-    priority
+  id
+  url
+  isAuthorized
+  isDeleteDialogAction
+  action
+  authorizationAttribute
+  priority
+  httpMethod
+  title {
+    languageCode
+    value
+  }
+  prompt {
+    value
+    languageCode
+  }
 }
 
 fragment DialogContentFields on ContentValue {

--- a/packages/frontend/src/api/useDialogById.tsx
+++ b/packages/frontend/src/api/useDialogById.tsx
@@ -6,7 +6,7 @@ import type {
   PartyFieldsFragment,
 } from 'bff-types-generated';
 import { useQuery } from 'react-query';
-import type { GuiButtonProps } from '../components';
+import type { GuiActionButtonProps } from '../components';
 import { i18n } from '../i18n/config.ts';
 import { type FormatFunction, useFormat } from '../i18n/useDateFnsLocale.tsx';
 import { getOrganisation } from './organisations.ts';
@@ -35,10 +35,11 @@ export interface DialogByIdDetails {
   receiver: Participant;
   title: string;
   tags: InboxItemTag[];
-  guiActions: GuiButtonProps[];
+  guiActions: GuiActionButtonProps[];
   additionalInfo: string | React.ReactNode;
   attachments: AttachmentFieldsFragment[];
   mainContentReference?: MainContentReference;
+  dialogToken: string;
 }
 
 interface UseDialogByIdOutput {
@@ -135,11 +136,15 @@ export function mapDialogDtoToInboxItem(
       url: guiAction.url,
       hidden: !guiAction.isAuthorized,
       priority: guiAction.priority,
-      method: guiAction.action,
+      httpMethod: guiAction.action,
       title: getPropertyByCultureCode(guiAction.title),
+      prompt: getPropertyByCultureCode(guiAction.prompt),
+      isDeleteAction: guiAction.isDeleteDialogAction,
+      disabled: !guiAction.isAuthorized,
     })),
     attachments: item.attachments,
     mainContentReference: getMainContentReference(mainContentReference),
+    dialogToken: item.dialogToken!,
   };
 }
 

--- a/packages/frontend/src/components/InboxItem/GuiActions.tsx
+++ b/packages/frontend/src/components/InboxItem/GuiActions.tsx
@@ -1,48 +1,88 @@
 import { Button } from '@digdir/designsystemet-react';
 import type { GuiActionPriority } from 'bff-types-generated';
-
 import styles from './guiActions.module.css';
 
-export interface GuiButtonProps {
+export interface GuiActionProps {
+  actions: GuiActionButtonProps[];
+  onDeleteSuccess: () => void;
+  dialogToken: string;
+}
+
+export interface GuiActionButtonProps {
   id: string;
   url: string;
   priority: GuiActionPriority;
-  method: string;
+  isDeleteAction: boolean;
+  httpMethod: string;
   title: string;
+  prompt?: string;
   disabled?: boolean;
 }
-export interface GuiActionProps {
-  actions: GuiButtonProps[];
+
+interface GuiActionsProps {
+  actions: GuiActionButtonProps;
+  dialogToken: string;
+  onDeleteSuccess: () => void;
 }
+
+/**
+ * Handles the button click event based on HTTP method.
+ *
+ * @param {GuiActionButton} props - The properties passed to the button component.
+ * @param dialogToken - The dialog token used for authorization.
+ * @param onDeleteSuccess - The callback function to execute after a successful delete action.
+ */
+const handleButtonClick = async (props: GuiActionButtonProps, dialogToken: string, onDeleteSuccess?: () => void) => {
+  const { url, httpMethod, prompt, isDeleteAction } = props;
+
+  if (prompt && !window.confirm(prompt)) {
+    return;
+  }
+
+  if (httpMethod === 'GET') {
+    window.location.href = url;
+  } else {
+    try {
+      const response = await fetch(url, {
+        method: httpMethod,
+        headers: {
+          Authorization: `Bearer ${dialogToken}`,
+        },
+      });
+
+      if (!response.ok) {
+        console.log(`Error: ${response.statusText}`);
+      }
+
+      if (isDeleteAction) {
+        onDeleteSuccess?.();
+      }
+    } catch (error) {
+      console.error('Error performing action:', error);
+    }
+  }
+};
 
 /**
  * Renders a single action button with the specified properties.
  *
  * @component
- * @param {GuiButtonProps} props - The properties passed to the button component.
- * @param {string} props.id - The unique identifier for the button.
- * @param {string} props.url - The URL to which the form will be submitted.
- * @param {boolean} props.disabled - Determines if the button should be disabled.
- * @param {GuiActionPriority} props.priority - The priority of the action, which determines the button variant.
- * @param {string} props.method - The HTTP method to use when submitting the form (e.g., "POST").
- * @param {string} props.title - The text to display on the button.
+ * @param {GuiActionButton} props - The properties passed to the button component.
  * @returns {JSX.Element | null} The rendered button or null if hidden.
  */
-const GuiActionButton = ({
-  priority,
-  method,
-  url,
-  id,
-  title,
-  disabled = false,
-}: GuiButtonProps): JSX.Element | null => {
+const GuiActionButton = ({ actions, dialogToken, onDeleteSuccess }: GuiActionsProps): JSX.Element | null => {
+  const { priority, id, title, disabled = false } = actions;
   const variant = priority.toLowerCase() as 'primary' | 'secondary' | 'tertiary';
+
   return (
-    <form id={id} action={url} method={method}>
-      <Button type="submit" variant={variant} disabled={disabled}>
-        {title}
-      </Button>
-    </form>
+    <Button
+      id={id}
+      variant={variant}
+      disabled={disabled}
+      onClick={() => handleButtonClick(actions, dialogToken, onDeleteSuccess)}
+    >
+      {title}
+    </Button>
   );
 };
 
@@ -51,22 +91,28 @@ const GuiActionButton = ({
  *
  * @component
  * @param {GuiActionProps} props - The properties passed to the component.
- * @param {GuiButtonProps[]} props.actions - An array of action button properties.
  * @returns {JSX.Element} The container with all rendered action buttons.
  *
  * @example
  * <GuiActions
+     onDeleteSuccess={() => console.log('Deleted')}
  *   actions={[
- *     { id: 'btn1', url: '/submit', disabled: false, priority: 'Primary', method: 'POST', title: 'Submit' },
- *     { id: 'btn2', url: '/cancel', disabled: false, priority: 'Secondary', method: 'GET', title: 'Cancel' },
+ *     { id: 'btn1', url: '/submit', disabled: false, priority: 'Primary', httpMethod: 'POST', title: 'Submit', dialogToken: 'token123' },
+ *     { id: 'btn2', url: '/cancel', disabled: false, priority: 'Secondary', httpMethod: 'GET', title: 'Cancel', dialogToken: 'token123' },
  *   ]}
+ *   dialogToken="your-dialog-token"
  * />
  */
-export const GuiActions = ({ actions }: GuiActionProps): JSX.Element => {
+export const GuiActions = ({ actions, dialogToken, onDeleteSuccess }: GuiActionProps): JSX.Element => {
   return (
     <section className={styles.guiActions}>
-      {actions.map((buttonProps) => (
-        <GuiActionButton key={buttonProps.id} {...buttonProps} />
+      {actions.map((actionProps) => (
+        <GuiActionButton
+          key={actionProps.id}
+          actions={actionProps}
+          dialogToken={dialogToken}
+          onDeleteSuccess={onDeleteSuccess}
+        />
       ))}
     </section>
   );

--- a/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
@@ -61,6 +61,7 @@ const MainContentReference = (args: DialogByIdDetails['mainContentReference']) =
 export const InboxItemDetail = ({
   dialog: {
     title,
+    dialogToken,
     description,
     sender,
     receiver,
@@ -95,7 +96,13 @@ export const InboxItemDetail = ({
         ) : (
           <div>{description}</div>
         )}
-        <GuiActions actions={guiActions} />
+        <GuiActions
+          actions={guiActions}
+          dialogToken={dialogToken}
+          onDeleteSuccess={() => {
+            // TODO: Redirect to inbox
+          }}
+        />
         <div className={styles.tags}>
           {tags.map((tag) => (
             <div key={tag.label} className={styles.tag}>

--- a/packages/storybook/src/stories/GuiActions/guiActions.stories.tsx
+++ b/packages/storybook/src/stories/GuiActions/guiActions.stories.tsx
@@ -10,7 +10,25 @@ export default {
       description: 'Array of action button properties',
       table: {
         type: {
-          summary: 'GuiButtonProps[]',
+          summary: 'GuiActionButton[]',
+        },
+      },
+    },
+    dialogToken: {
+      control: 'text',
+      description: 'Authorization token for dialog actions',
+      table: {
+        type: {
+          summary: 'string',
+        },
+      },
+    },
+    onDeleteSuccess: {
+      control: 'function',
+      description: 'Callback function to execute after a successful delete action',
+      table: {
+        type: {
+          summary: '() => void',
         },
       },
     },
@@ -22,20 +40,68 @@ const Template: StoryFn<GuiActionProps> = (args) => <GuiActions {...args} />;
 export const Default = Template.bind({});
 Default.args = {
   actions: [
-    { id: 'btn1', url: '/submit', disabled: false, priority: 'Primary', method: 'POST', title: 'Submit' },
-    { id: 'btn2', url: '/cancel', disabled: false, priority: 'Secondary', method: 'GET', title: 'Cancel' },
+    {
+      id: 'btn1',
+      url: '/submit',
+      disabled: false,
+      priority: 'Primary',
+      httpMethod: 'POST',
+      title: 'Submit',
+      isDeleteAction: false,
+    },
+    {
+      id: 'btn2',
+      url: '/cancel',
+      disabled: false,
+      priority: 'Secondary',
+      httpMethod: 'GET',
+      title: 'Cancel',
+      isDeleteAction: false,
+    },
   ],
+  dialogToken: 'your-dialog-token',
+  onDeleteSuccess: () => console.log('Deleted'),
 };
 
 export const withDisabledButton = Template.bind({});
 withDisabledButton.args = {
   actions: [
-    { id: 'btn1', url: '/submit', disabled: false, priority: 'Primary', method: 'POST', title: 'Submit' },
-    { id: 'btn2', url: '/cancel', disabled: true, priority: 'Secondary', method: 'GET', title: 'Cancel' },
+    {
+      id: 'btn1',
+      url: '/submit',
+      disabled: false,
+      priority: 'Primary',
+      httpMethod: 'POST',
+      title: 'Submit',
+      isDeleteAction: false,
+    },
+    {
+      id: 'btn2',
+      url: '/cancel',
+      disabled: true,
+      priority: 'Secondary',
+      httpMethod: 'GET',
+      title: 'Cancel',
+      isDeleteAction: false,
+    },
   ],
+  dialogToken: 'your-dialog-token',
+  onDeleteSuccess: () => console.log('Deleted'),
 };
 
 export const TertiaryPriority = Template.bind({});
 TertiaryPriority.args = {
-  actions: [{ id: 'btn1', url: '/info', disabled: false, priority: 'Tertiary', method: 'GET', title: 'Info' }],
+  actions: [
+    {
+      id: 'btn1',
+      url: '/info',
+      disabled: false,
+      priority: 'Tertiary',
+      httpMethod: 'GET',
+      title: 'Info',
+      isDeleteAction: false,
+    },
+  ],
+  dialogToken: 'your-dialog-token',
+  onDeleteSuccess: () => console.log('Deleted'),
 };


### PR DESCRIPTION
Prøver å følge spesfikasjonene nedskrevet https://digdir.github.io/dialogporten/#gui-handlinger så tett som mulig.

Det er vanskelig å teste, dvs jeg kan teste mot et mock-endepunkt, men får ikke testet autentiseringsdelen av det.

Fikser #778 (resten 👇 er resteoppgave som krever detaljering):

Kjente mangler (ikke besvart av design):
- Hva skal skje dersom bruker ikke er autentisert til å utføre action (p.t. er knappen deaktivert, men synlig). Bør det forklares hvorfor den er deaktivert?
- Hva skal skje når en dialog slettes som følge av en delete-action (nærliggende at man får redirect til hovedsiden) 

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->