### PR TITLE
fix: Arrow alignment in search dropdown

### DIFF
--- a/packages/frontend/src/components/Header/SearchDropdown.tsx
+++ b/packages/frontend/src/components/Header/SearchDropdown.tsx
@@ -45,7 +45,7 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({ showDropdownMenu
           </div>
           <div className={styles.rightContent}>
             <span className={styles.keyText}>Return</span>
-            <ChevronRightIcon className={styles.arrowIcon} />
+            <ChevronRightIcon fontSize={24} className={styles.arrowIcon} />
           </div>
         </SearchDropdownItem>
 

--- a/packages/frontend/src/components/Header/search.module.css
+++ b/packages/frontend/src/components/Header/search.module.css
@@ -184,14 +184,15 @@ input:focus-visible {
 }
 
 .arrowIcon {
-  margin-right: 0.5rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   color: #000;
+
+  > svg {
+    min-width: 100%;
+    min-height: 100%;
+  }
 }
 
 .link {

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesItem.tsx
@@ -1,6 +1,6 @@
 import { DropdownMenu } from '@digdir/designsystemet-react';
-import { ChevronRightIcon, EllipsisHorizontalIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { PencilIcon } from '@navikt/aksel-icons';
+import { EllipsisHorizontalIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { ChevronRightIcon, PencilIcon } from '@navikt/aksel-icons';
 import type { SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,6 +18,7 @@ export interface OpenSavedSearchLinkProps {
   savedSearch: SavedSearchesFieldsFragment;
   onClick?: () => void;
 }
+
 export const OpenSavedSearchLink = ({ savedSearch, onClick }: OpenSavedSearchLinkProps) => {
   const { searchString, filters, fromView } = savedSearch.data;
   const queryParams = new URLSearchParams({
@@ -26,7 +27,7 @@ export const OpenSavedSearchLink = ({ savedSearch, onClick }: OpenSavedSearchLin
   });
   return (
     <a href={`${fromView}?${queryParams.toString()}`}>
-      <ChevronRightIcon className={styles.icon} onClick={onClick} />
+      <ChevronRightIcon fontSize={24} className={styles.icon} onClick={onClick} />
     </a>
   );
 };
@@ -53,7 +54,7 @@ const RenderButtons = ({ savedSearch, onDelete, setSelectedSavedSearch }: SavedS
               <div className={styles.dropdownEditSearch}>
                 <PencilIcon fontSize="1.5rem" aria-hidden="true" />
                 <span>{t('savedSearches.change_name')}</span>
-                <ChevronRightIcon className={styles.icon} />
+                <ChevronRightIcon fontSize={24} className={styles.icon} />
               </div>
             </DropdownMenu.Item>
             <hr />


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->
Now looks like this:

![CleanShot 2024-08-01 at 15 22 48@2x](https://github.com/user-attachments/assets/7fa73de8-bfe8-4834-ae1b-df6b51ad7410)

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->