### PR TITLE
fix: fix layout for search bar on mobile and mobile

### DIFF
--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -2,7 +2,6 @@ import type React from 'react';
 import { useEffect } from 'react';
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useWindowSize } from '../../../utils/useWindowSize';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/queryParams';
 import { MenuBar } from '../MenuBar';
 import { AltinnLogo } from './AltinnLogo';
@@ -58,15 +57,15 @@ export const useSearchString = () => {
  */
 
 export const Header: React.FC<HeaderProps> = ({ name, companyName, notificationCount }) => {
-  const { isMobile } = useWindowSize();
   return (
     <header data-testid="main-header">
       <nav className={styles.navigation} aria-label="Navigasjon">
         <AltinnLogo className={styles.logo} />
-        {!isMobile && <SearchBar />}
-        <MenuBar notificationCount={notificationCount} name={name} companyName={companyName} />
+        <SearchBar />
+        <div className={styles.hideOnMobile}>
+          <MenuBar notificationCount={notificationCount} name={name} companyName={companyName} />
+        </div>
       </nav>
-      {isMobile && <SearchBar />}
     </header>
   );
 };

--- a/packages/frontend/src/components/Header/SearchBar.tsx
+++ b/packages/frontend/src/components/Header/SearchBar.tsx
@@ -75,10 +75,10 @@ export const SearchBar: React.FC = () => {
           <button
             type="button"
             onClick={searchValue ? onClearSearch : onClearAndCloseDropdown}
-            className={cx(styles.clearButton)}
+            className={styles.clearButton}
             aria-label={t('header.clearSearch')}
           >
-            <MultiplyIcon className={cx(styles.clearButtonIcon, { [styles.withBackground]: !searchValue })} />
+            <MultiplyIcon className={cx(styles.clearButtonIcon, { [styles.withBackground]: !!searchValue })} />
           </button>
         )}
       </div>

--- a/packages/frontend/src/components/Header/header.module.css
+++ b/packages/frontend/src/components/Header/header.module.css
@@ -20,6 +20,19 @@
   min-width: 7.75rem;
 }
 
+@media screen and (max-width: 1024px) {
+  .logo {
+    display: none;
+  }
+  .hideOnMobile {
+    display: none;
+  }
+
+  .navigation {
+    display: block;
+  }
+}
+
 .logo span {
   margin-left: 4px;
   font-weight: 500;
@@ -33,12 +46,5 @@
     border-radius: 6px;
     border: 2px solid #000;
     background-color: inherit;
-  }
-}
-
-@media screen and (max-width: 768px) {
-  .searchBar {
-    padding: 1rem;
-    margin: 0;
   }
 }

--- a/packages/frontend/src/components/Header/search.module.css
+++ b/packages/frontend/src/components/Header/search.module.css
@@ -8,7 +8,6 @@
   height: 2.25rem;
   max-height: 2.25rem;
   user-select: none;
-  margin-left: 1rem;
 }
 
 .inputContainer {
@@ -87,7 +86,7 @@ input:focus-visible {
   left: 0;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   z-index: 1002;
-  width: 320px;
+  width: 100%;
   opacity: 0.4;
   transition: width 0.2s ease, opacity 0.2s ease;
 }
@@ -101,7 +100,8 @@ input:focus-visible {
 .showDropdownMenu {
   border: 3px solid #000;
   border-radius: 0 0 6px 6px;
-  width: 672px;
+  width: 100%;
+  box-sizing: border-box;
   opacity: 1;
 }
 
@@ -255,27 +255,12 @@ input:focus-visible {
   padding: 0.25rem 0.625rem;
 }
 
-@media screen and (max-width: 768px) {
-  .menuItems {
-    left: 0;
-    width: 100%;
-    position: fixed;
-    top: 9.375rem;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    z-index: 1002;
-  }
-
-  .menuList {
-    width: 100%;
-    min-height: 100vh;
-  }
-
+@media screen and (max-width: 1024px) {
   .inputContainer {
-    width: 100%;
+    width: calc(100% - 2rem);
+    margin: 0 auto;
   }
-
   .searchbarContainer {
-    margin-left: 1rem;
-    margin-right: 1rem;
+    padding-top: 0.5rem;
   }
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/97b1a01e-f5fe-434a-a7a8-84c9a1bd80c1)

Justerer layout for søkefelt slik at den ser likt ut på mobil og tablet.
Fikser også et par animasjon- og margin-glitcher. Header er nå forenklet og er pure css mtp layout.



## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->