### PR TITLE
feat: add xs size for profile button + small fixes in header

### DIFF
--- a/packages/docs/src/pages/index.module.css
+++ b/packages/docs/src/pages/index.module.css
@@ -10,7 +10,7 @@
   overflow: hidden;
 }
 
-@media screen and (max-width: 996px) {
+@media screen and (max-width: 1024px) {
   .heroBanner {
     padding: 2rem;
   }

--- a/packages/frontend/src/components/DropdownMenu/DropdownMobileHeader/dropdownMobileHeader.module.css
+++ b/packages/frontend/src/components/DropdownMenu/DropdownMobileHeader/dropdownMobileHeader.module.css
@@ -4,7 +4,7 @@
   button {
     padding: 0;
   }
-  @media screen and (min-width: 996px) {
+  @media screen and (min-width: 1024px) {
     display: none;
   }
 }

--- a/packages/frontend/src/components/DropdownMenu/dropdownList.module.css
+++ b/packages/frontend/src/components/DropdownMenu/dropdownList.module.css
@@ -19,7 +19,7 @@
   max-width: 195px;
 }
 
-@media screen and (max-width: 996px) {
+@media screen and (max-width: 1024px) {
   .dropdownList {
     position: fixed;
     left: 0;

--- a/packages/frontend/src/components/FilterBar/AddFilterButton/AddFilterButton.tsx
+++ b/packages/frontend/src/components/FilterBar/AddFilterButton/AddFilterButton.tsx
@@ -35,14 +35,14 @@ export const AddFilterButton = ({
   return (
     <div className={cx({ [styles.filterOpen]: isMenuOpen })}>
       <ProfileButton
-        size="sm"
+        size="xs"
         onClick={onAddBtnClick}
         className={className}
         disabled={disabled}
         variant="secondary"
         color="neutral"
       >
-        <PlusIcon fontSize="1.5rem" /> {t('filter_bar.add_filter')}
+        <PlusIcon fontSize="1.25rem" /> {t('filter_bar.add_filter')}
       </ProfileButton>
       {isMenuOpen && (
         <DropdownList variant="long">

--- a/packages/frontend/src/components/FilterBar/FilterButton/FilterButton.tsx
+++ b/packages/frontend/src/components/FilterBar/FilterButton/FilterButton.tsx
@@ -103,6 +103,7 @@ export const FilterButtonSection = ({ date, onListItemClick, id, onBack }: Filte
           onListItemClick(id, `${startDate || minDate}/${endDate || maxDate}`, true);
         }}
         variant="secondary"
+        size="xs"
       >
         {t('filter_bar.choose_date')}
       </ProfileButton>
@@ -163,17 +164,21 @@ export const FilterButton = ({
   return (
     <div className={styles.filterButton}>
       <div className={styles.buttons}>
-        <ProfileButton onClick={onBtnClick} className={cx({ [styles.xed]: hoveringDeleteBtn })} size="sm">
+        <ProfileButton
+          onClick={onBtnClick}
+          className={cx(styles.removeFilterButton, { [styles.xed]: hoveringDeleteBtn })}
+          size="xs"
+        >
           {dateInfo.isDate ? dateInfo.label : displayLabel}
         </ProfileButton>
         <ProfileButton
-          size="sm"
-          className={styles.button}
+          size="xs"
+          className={styles.xableButton}
           onClick={() => onRemove(id)}
           onMouseEnter={() => setHoveringDeleteBtn(true)}
           onMouseLeave={() => setHoveringDeleteBtn(false)}
         >
-          <XMarkIcon />
+          <XMarkIcon fontSize="1.5rem" />
         </ProfileButton>
       </div>
       {isOpen && (

--- a/packages/frontend/src/components/FilterBar/FilterButton/filterButton.module.css
+++ b/packages/frontend/src/components/FilterBar/FilterButton/filterButton.module.css
@@ -1,12 +1,22 @@
-.filterButton {
-  button {
-    border-radius: 0;
-  }
-}
-
 .buttons {
   z-index: 1001;
   display: flex;
+}
+
+.xIcon {
+  background-color: #1e98f5;
+}
+
+.removeFilterButton {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: 1px solid #fff;
+  box-sizing: border-box;
+}
+
+.xableButton {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 .xed {

--- a/packages/frontend/src/components/FosToolbar/fosToolbar.module.css
+++ b/packages/frontend/src/components/FosToolbar/fosToolbar.module.css
@@ -16,7 +16,7 @@
   bottom: 20px;
 }
 
-@media screen and (min-width: 996px) {
+@media screen and (min-width: 1024px) {
   .fosToolbar {
     display: none;
   }

--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useEffect } from 'react';
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useWindowSize } from '../../../utils/useWindowSize.tsx';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/queryParams';
 import { MenuBar } from '../MenuBar';
 import { AltinnLogo } from './AltinnLogo';
@@ -57,15 +58,16 @@ export const useSearchString = () => {
  */
 
 export const Header: React.FC<HeaderProps> = ({ name, companyName, notificationCount }) => {
+  const { width } = useWindowSize();
+  const isMobile = (width ?? 0) <= 1024;
   return (
     <header data-testid="main-header">
       <nav className={styles.navigation} aria-label="Navigasjon">
         <AltinnLogo className={styles.logo} />
-        <SearchBar />
-        <div className={styles.hideOnMobile}>
-          <MenuBar notificationCount={notificationCount} name={name} companyName={companyName} />
-        </div>
+        {!isMobile && <SearchBar />}
+        <MenuBar notificationCount={notificationCount} name={name} companyName={companyName} />
       </nav>
+      {isMobile && <SearchBar />}
     </header>
   );
 };

--- a/packages/frontend/src/components/Header/SearchBar.tsx
+++ b/packages/frontend/src/components/Header/SearchBar.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useWindowSize } from '../../../utils/useWindowSize.tsx';
 import { Backdrop } from '../Backdrop';
 import { useSearchString } from '../Header';
 import { SearchDropdown } from './SearchDropdown';
@@ -15,6 +16,8 @@ export const SearchBar: React.FC = () => {
   const { searchString, setSearchString } = useSearchString();
   const [searchValue, setSearchValue] = useState<string>(searchString);
   const navigate = useNavigate();
+  const { width } = useWindowSize();
+  const isMobile = (width ?? 0) <= 1024;
 
   const handleClose = () => {
     setShowDropdownMenu(false);
@@ -57,7 +60,15 @@ export const SearchBar: React.FC = () => {
           type="text"
           autoComplete="off"
           onClick={() => setShowDropdownMenu(true)}
-          onFocus={() => setShowDropdownMenu(true)}
+          onFocus={() => {
+            setShowDropdownMenu(true);
+            if (isMobile) {
+              window.scroll({
+                top: 65,
+                behavior: 'smooth',
+              });
+            }
+          }}
           aria-label={t('header.searchPlaceholder')}
           placeholder={t('header.searchPlaceholder')}
           className={cx(styles.searchInput)}

--- a/packages/frontend/src/components/Header/header.module.css
+++ b/packages/frontend/src/components/Header/header.module.css
@@ -7,6 +7,18 @@
   max-height: 68px;
 }
 
+.navigationTablet {
+  display: flex;
+  flex-direction: column;
+  color: var(--Company-Primary, #111d46);
+  padding: 16px;
+  max-height: 68px;
+}
+
+.adjustPadding {
+  padding-left: 2rem;
+}
+
 .logo a {
   color: #000;
   text-align: center;
@@ -18,19 +30,6 @@
   display: flex;
   align-items: center;
   min-width: 7.75rem;
-}
-
-@media screen and (max-width: 1024px) {
-  .logo {
-    display: none;
-  }
-  .hideOnMobile {
-    display: none;
-  }
-
-  .navigation {
-    display: block;
-  }
 }
 
 .logo span {

--- a/packages/frontend/src/components/Header/search.module.css
+++ b/packages/frontend/src/components/Header/search.module.css
@@ -25,7 +25,7 @@
 }
 
 .inputContainer.searchbarOpen {
-  border: 3px solid #000;
+  border: 2px solid #000;
   border-radius: 6px 6px 0 0;
 }
 
@@ -98,7 +98,7 @@ input:focus-visible {
 }
 
 .showDropdownMenu {
-  border: 3px solid #000;
+  border: 2px solid #000;
   border-radius: 0 0 6px 6px;
   width: 100%;
   box-sizing: border-box;
@@ -262,5 +262,7 @@ input:focus-visible {
   }
   .searchbarContainer {
     padding-top: 0.5rem;
+    width: calc(100% - 2rem);
+    margin: 0 auto;
   }
 }

--- a/packages/frontend/src/components/MenuBar/navigationDropdownMenu.module.css
+++ b/packages/frontend/src/components/MenuBar/navigationDropdownMenu.module.css
@@ -28,7 +28,7 @@
   z-index: 1001;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 1024px) {
   .menuItems {
     left: 0;
     width: calc(100% - 1rem);

--- a/packages/frontend/src/components/PartyDropdown/PartyDropdown.tsx
+++ b/packages/frontend/src/components/PartyDropdown/PartyDropdown.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon } from '@navikt/aksel-icons';
+import { ChevronUpDownIcon } from '@navikt/aksel-icons';
 import { type Ref, forwardRef, useImperativeHandle, useMemo, useState } from 'react';
 import { useDialogs } from '../../api/useDialogs.tsx';
 import { useParties } from '../../api/useParties.ts';
@@ -57,9 +57,9 @@ export const PartyDropdown = forwardRef((_: unknown, ref: Ref<PartyDropdownRef>)
 
   return (
     <>
-      <ProfileButton size="sm" onClick={() => setIsMenuOpen(!isMenuOpen)} color="neutral">
+      <ProfileButton size="xs" onClick={() => setIsMenuOpen(!isMenuOpen)} color="neutral">
         {selectedParties.length === 1 ? selectedParties[0].name : t('partydropdown.all_parties')}
-        <ChevronDownIcon fontSize="1.5rem" />
+        <ChevronUpDownIcon fontSize="1.25rem" />
       </ProfileButton>
       {isMenuOpen && (
         <DropdownList variant="long">

--- a/packages/frontend/src/components/ProfileButton/ProfileButton.tsx
+++ b/packages/frontend/src/components/ProfileButton/ProfileButton.tsx
@@ -6,15 +6,17 @@ import styles from './profileButton.module.css';
 
 type ProfileButtonProps = {
   isLoading?: boolean;
-} & ButtonProps;
+  size?: 'xs' | 'sm' | 'md' | 'lg';
+} & Omit<ButtonProps, 'size'>;
 
 export const ProfileButton = (props: ProfileButtonProps) => {
   const { t } = useTranslation();
-  const { className, isLoading, children, variant = 'primary', ...restProps } = props;
+  const { className, isLoading, children, variant = 'primary', size, ...restProps } = props;
   const classes = cx(className, styles.profileButton, {
     [styles.primary]: variant === 'primary',
     [styles.secondary]: variant === 'secondary',
     [styles.tertiary]: variant === 'tertiary',
+    [styles.xs]: size === 'xs',
   });
 
   if (isLoading) {

--- a/packages/frontend/src/components/ProfileButton/profileButton.module.css
+++ b/packages/frontend/src/components/ProfileButton/profileButton.module.css
@@ -18,3 +18,14 @@
   background: var(--background-color);
   color: 1px dashed var(--button-color);
 }
+
+.xs {
+  border-radius: .125rem;
+  font-size: .875rem;
+  min-height: 36px;
+  height: 36px;
+  box-sizing: border-box;
+  padding: 0.625rem 0.5rem;
+  font-weight: 500;
+  column-gap: 7px;
+}

--- a/packages/frontend/src/components/SavedSearchButton/SaveSearchButton.tsx
+++ b/packages/frontend/src/components/SavedSearchButton/SaveSearchButton.tsx
@@ -18,8 +18,8 @@ export const SaveSearchButton = ({ disabled, onBtnClick, className, isLoading }:
   }
 
   return (
-    <ProfileButton size="sm" className={className} onClick={onBtnClick} variant="secondary" isLoading={isLoading}>
-      <BookmarkIcon fontSize="1.5rem" /> {t('filter_bar.save_search')}
+    <ProfileButton className={className} size="xs" onClick={onBtnClick} variant="tertiary" isLoading={isLoading}>
+      <BookmarkIcon fontSize="1.25rem" /> {t('filter_bar.save_search')}
     </ProfileButton>
   );
 };

--- a/packages/frontend/src/components/SortOrderDropdown/SortOrderDropdown.tsx
+++ b/packages/frontend/src/components/SortOrderDropdown/SortOrderDropdown.tsx
@@ -57,9 +57,9 @@ export const SortOrderDropdown = forwardRef(
           onClick={() => setIsOpen(!isOpen)}
           className={cx(styles.openBtn, btnClassName)}
           variant="secondary"
-          size="sm"
+          size="xs"
         >
-          <ArrowsUpDownIcon fontSize="1.5rem" />
+          <ArrowsUpDownIcon fontSize="1.25rem" />
           {selectedOptionLabel}
         </ProfileButton>
         {isOpen && (

--- a/packages/frontend/src/pages/Inbox/inbox.module.css
+++ b/packages/frontend/src/pages/Inbox/inbox.module.css
@@ -8,10 +8,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding-top: 1rem;
+  padding-top: 1.25rem;
 
   @media (max-width: 1024px) {
-    padding: 1rem;
+    padding: 1.5rem;
   }
 }
 
@@ -45,7 +45,7 @@
   }
 }
 
-@media screen and (max-width: 996px) {
+@media screen and (max-width: 1024px) {
   .hideForSmallScreens {
     display: none;
   }

--- a/packages/storybook/src/stories/ProfileButton/profileButton.stories.tsx
+++ b/packages/storybook/src/stories/ProfileButton/profileButton.stories.tsx
@@ -1,3 +1,4 @@
+import { BookmarkIcon } from '@navikt/aksel-icons';
 import type { Meta } from '@storybook/react';
 import { ProfileButton } from 'frontend/src/components/ProfileButton/ProfileButton.tsx';
 import { withRouter } from 'storybook-addon-react-router-v6';
@@ -44,6 +45,22 @@ export const PersonSecondary = () => {
   return (
     <ProfileButton size="sm" onClick={() => {}} variant="secondary">
       Secondary
+    </ProfileButton>
+  );
+};
+
+export const XsButton = () => {
+  return (
+    <ProfileButton size="xs" onClick={() => {}} variant="primary">
+      xs button
+    </ProfileButton>
+  );
+};
+
+export const XsButtonWithIcon = () => {
+  return (
+    <ProfileButton size="xs" onClick={() => {}} variant="primary">
+      xs button <BookmarkIcon fontSize="1.25rem" />
     </ProfileButton>
   );
 };


### PR DESCRIPTION
Legger til size `xs` til `ProfileButton` som brukes i dropdown-elementene.
Den har fått egen story i storybook, for ordens skyld.

![image](https://github.com/user-attachments/assets/a0d7865b-f8d5-499d-8e9a-86422c88b325)

Det var også tull med headeren og søkefeltet på mobil som var litt kritisk, så det er også en fiks på det.

Fikser #947 

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->