### PR TITLE
chore: bump dialogporten-schema to v. 1.11.0-161c42b

### DIFF
--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -20,7 +20,7 @@
     "@azure/app-configuration": "^1.4.1",
     "@azure/identity": "^4.0.0",
     "@azure/keyvault-keys": "^4.7.2",
-    "@digdir/dialogporten-schema": "1.8.1-3ca495f",
+    "@digdir/dialogporten-schema": "1.11.0-161c42b",
     "@fastify/cookie": "^9.3.1",
     "@fastify/cors": "^9.0.1",
     "@fastify/formbody": "^7.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^4.7.2
         version: 4.7.2
       '@digdir/dialogporten-schema':
-        specifier: 1.8.1-3ca495f
-        version: 1.8.1-3ca495f
+        specifier: 1.11.0-161c42b
+        version: 1.11.0-161c42b
       '@fastify/cookie':
         specifier: ^9.3.1
         version: 9.3.1
@@ -3779,8 +3779,8 @@ packages:
     resolution: {integrity: sha512-JWCLhXxDlMYwatg7mLkptfEkeiv/EKSaUOXX4nUoV8HjqyxMnLaaZZe6NKqx2SH1GPKOeSL5bEcs2NAEoFlGXg==}
     dev: false
 
-  /@digdir/dialogporten-schema@1.8.1-3ca495f:
-    resolution: {integrity: sha512-sZ+o9eM4Ku+odvo6zaCVkCqeQdnNozXSgXt7p29iW1cZL5KWmpm3hbXp2v2p1IeR0zn9U/+WiQgsIqHHkgv5vA==}
+  /@digdir/dialogporten-schema@1.11.0-161c42b:
+    resolution: {integrity: sha512-9s47Y/MqFCQ03JijJWBMAgZs/L3TWrA8aYM243l6bEAkZp9IzroRD+5NNxkwdQqQJRiEFMtYZKjJv0SGoG26+A==}
     engines: {node: '20'}
     dev: false
 


### PR DESCRIPTION
https://npmdiff.dev/%40digdir%2Fdialogporten-schema/1.8.1-3ca495f/1.11.0-161c42b/

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->