### PR TITLE
fix: change refresh auth token flow

### DIFF
--- a/packages/bff/src/auth/oidc.ts
+++ b/packages/bff/src/auth/oidc.ts
@@ -13,7 +13,9 @@ import jwt from 'jsonwebtoken';
 declare module 'fastify' {
   interface FastifyInstance {
     idporten: OAuth2Namespace;
-    verifyToken: (request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) => void;
+    verifyToken: (
+      shouldRefresh: boolean,
+    ) => (request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) => void;
   }
 
   interface IdportenToken {
@@ -131,7 +133,7 @@ const plugin: FastifyPluginAsync<CustomOICDPluginOptions> = async (fastify, opti
 
   fastify.get(
     '/api/logout',
-    { preValidation: fastify.verifyToken },
+    { preHandler: fastify.verifyToken(false) },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const token: SessionStorageToken = request.session.get('token');
       const postLogoutRedirectUri = `${hostname}/loggedout`;

--- a/packages/bff/src/auth/userApi.ts
+++ b/packages/bff/src/auth/userApi.ts
@@ -4,7 +4,7 @@ import fp from 'fastify-plugin';
 const plugin: FastifyPluginAsync = async (fastify, options) => {
   fastify.get(
     '/api/isAuthenticated',
-    { preValidation: fastify.verifyToken },
+    { preHandler: fastify.verifyToken(true) },
     async (request: FastifyRequest, reply: FastifyReply) => {
       try {
         reply.send({

--- a/packages/bff/src/graphql/api.ts
+++ b/packages/bff/src/graphql/api.ts
@@ -38,7 +38,7 @@ const plugin: FastifyPluginAsync = async (fastify, options) => {
 
   fastify.post(
     '/api/graphql',
-    { preValidation: fastify.verifyToken },
+    { preHandler: fastify.verifyToken(false) },
     createHandler({
       schema: stitchedSchema,
       context(request) {

--- a/packages/frontend/src/auth/api.ts
+++ b/packages/frontend/src/auth/api.ts
@@ -6,6 +6,7 @@ export const getIsAuthenticated = async (): Promise<boolean> => {
     });
     return response.status === 200;
   } catch (error) {
+    console.log('error', error);
     return false;
   }
 };

--- a/packages/frontend/src/auth/useAuthenticated.ts
+++ b/packages/frontend/src/auth/useAuthenticated.ts
@@ -3,8 +3,11 @@ import { useQuery } from 'react-query';
 import { getIsAuthenticated } from './api.ts';
 import { getStoredURL, isRedirectURL, removeStoredURL, saveURL } from './url.ts';
 
+/* Keeps session alive as soon as it is active, e.g. active tab in browser */
 export const useAuthenticated = () => {
-  const { data: isAuthenticated, isSuccess: isAuthenticatedSuccess } = useQuery('isAuthenticated', getIsAuthenticated);
+  const { data: isAuthenticated, isSuccess: isAuthenticatedSuccess } = useQuery('isAuthenticated', getIsAuthenticated, {
+    refetchInterval: 30 * 1000,
+  });
 
   useEffect(() => {
     const currentHref = window.location.href;

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -10,7 +10,7 @@ import { useParties } from '../../api/useParties.ts';
 import { useAuthenticated } from '../../auth';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/queryParams.ts';
 import { useSavedSearches } from '../../pages/SavedSearches/useSavedSearches.ts';
-import { useProfile } from '../../profile/useProfile';
+import { useProfile } from '../../profile';
 import { BottomDrawerContainer } from '../BottomDrawer';
 import { Snackbar } from '../Snackbar';
 import { SelectedDialogsContainer, useSelectedDialogs } from './SelectedDialogs.tsx';


### PR DESCRIPTION
Forsøk på å løse at man blir unødvendig logget ut.

P.t. refreshes token når tjenestekall gjøres mot BFF og auth_token er utløpt. 
Ettersom flere usynkroniserte kall gjøres i paralllell,. og alle disse vil se behov for å refreshe access_token, vil man få unødvendig refreshing av auth_tokens. For å forhindre dette, er det kun `isAuthenticated`-endepunktet nå som er master og som triggrer en refresh dersom `auth_token` er utløpt. `isAuthenticated` kalles fra klienten hvert 30. sekund for å holde tokenet varmt (for å forhindre utlogging). Forutsetter at tab er aktiv / side er aktiv. 


Mangler (mulige forbedringer som kan avventes):
- Burde ha retries på refreshing av auth_token?
- Kunne refreshe token før det uløper.


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->