### PR TITLE
feat: Searches now being saved per party. Party dropdown and sidebar …

### DIFF
--- a/packages/bff-types-generated/queries/savedSearchesFields.fragment.graphql
+++ b/packages/bff-types-generated/queries/savedSearchesFields.fragment.graphql
@@ -4,6 +4,7 @@ fragment SavedSearchesFields on SavedSearches {
     createdAt
     updatedAt
     data {
+      urn
       searchString
       fromView
       filters {

--- a/packages/bff/src/graphql/types/savedSearches.ts
+++ b/packages/bff/src/graphql/types/savedSearches.ts
@@ -86,6 +86,7 @@ export const SavedSearchInput = inputObjectType({
   definition(t) {
     t.string('searchString');
     t.string('fromView');
+    t.string('urn');
     t.list.field('filters', { type: 'SearchDataValueFilterInput' });
   },
 });
@@ -152,6 +153,12 @@ export const SavedSearchData = objectType({
       description: 'fromView of savedSearch',
       resolve: (source, args, ctx, info) => {
         return source.fromView;
+      },
+    });
+    t.string('urn', {
+      description: 'urn of savedSearch',
+      resolve: (source, args, ctx, info) => {
+        return source.urn;
       },
     });
     t.field('filters', {

--- a/packages/frontend/src/components/GlobalMenuBar/NavigationDropdownSubMenuInbox.tsx
+++ b/packages/frontend/src/components/GlobalMenuBar/NavigationDropdownSubMenuInbox.tsx
@@ -7,7 +7,6 @@ import {
   InboxFillIcon,
   TrashIcon,
 } from '@navikt/aksel-icons';
-import type { SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { useDialogs } from '../../api/useDialogs.tsx';
@@ -23,9 +22,8 @@ import styles from './navigationDropdownMenu.module.css';
 
 export const NavigationDropdownSubMenuInbox: React.FC<DropdownSubMenuProps> = ({ onClose, onBack }) => {
   const { t } = useTranslation();
-  const { data } = useSavedSearches();
+  const { savedSearches } = useSavedSearches();
   const { pathname } = useLocation();
-  const savedSearches = data?.savedSearches as SavedSearchesFieldsFragment[];
   const { parties } = useParties();
   const { dialogsByView } = useDialogs(parties);
 

--- a/packages/frontend/src/components/Header/SearchDropdown.tsx
+++ b/packages/frontend/src/components/Header/SearchDropdown.tsx
@@ -1,5 +1,4 @@
 import { ChevronRightIcon } from '@navikt/aksel-icons';
-import type { SavedSearchesFieldsFragment } from 'bff-types-generated';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useSearchDialogs } from '../../api/useDialogs';
@@ -25,8 +24,7 @@ interface SearchDropdownProps {
 
 export const SearchDropdown: React.FC<SearchDropdownProps> = ({ showDropdownMenu, onClose, searchValue, onSearch }) => {
   const { t } = useTranslation();
-  const { data, isLoading: isLoadingSavedSearches } = useSavedSearches();
-  const savedSearches = data?.savedSearches as SavedSearchesFieldsFragment[];
+  const { savedSearches, isLoading: isLoadingSavedSearches } = useSavedSearches();
   const { parties } = useParties();
   const { searchResults, isFetching } = useSearchDialogs({ parties, searchString: searchValue });
   const formatDistance = useFormatDistance();

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -36,14 +36,14 @@ const PageLayoutContent: React.FC<PageLayoutContentProps> = memo(
     const { inSelectionMode } = useSelectedDialogs();
     const { isTabletOrSmaller } = useWindowSize();
     const showSidebar = !isTabletOrSmaller && !inSelectionMode;
-    const { data: savedSearchesData } = useSavedSearches();
     const { selectedParties } = useParties();
+    const { currentPartySavedSearches } = useSavedSearches(selectedParties?.[0]);
     const { dialogsByView } = useDialogs(selectedParties);
     const itemsPerViewCount = {
       inbox: dialogsByView.inbox.length,
       drafts: dialogsByView.drafts.length,
       sent: dialogsByView.sent.length,
-      'saved-searches': savedSearchesData?.savedSearches?.length ?? 0,
+      'saved-searches': currentPartySavedSearches?.length ?? 0,
       archive: 0,
       deleted: 0,
     } as ItemPerViewCount;

--- a/packages/frontend/src/components/PartyDropdown/PartyDropdown.tsx
+++ b/packages/frontend/src/components/PartyDropdown/PartyDropdown.tsx
@@ -5,12 +5,19 @@ import { useParties } from '../../api/useParties.ts';
 import { Backdrop } from '../Backdrop';
 import { DropdownList, DropdownMobileHeader } from '../DropdownMenu';
 import { ProfileButton } from '../ProfileButton';
+import type { SideBarView } from '../Sidebar/Sidebar.tsx';
 import { PartyList } from './PartyList.tsx';
 
 interface PartyDropdownRef {
   openPartyDropdown: () => void;
 }
-export const PartyDropdown = forwardRef((_: unknown, ref: Ref<PartyDropdownRef>) => {
+
+interface PartyDropdownProps {
+  counterContext?: SideBarView;
+}
+
+export const PartyDropdown = forwardRef((_: PartyDropdownProps, ref: Ref<PartyDropdownRef>) => {
+  const { counterContext } = _;
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const { t } = useTranslation();
   const { selectedParties } = useParties();
@@ -24,7 +31,7 @@ export const PartyDropdown = forwardRef((_: unknown, ref: Ref<PartyDropdownRef>)
   return (
     <div>
       <ProfileButton size="xs" onClick={() => setIsMenuOpen(!isMenuOpen)} color="neutral">
-        {selectedParties[0]?.name ?? t('partyDropdown.selectParty')}
+        {selectedParties?.[0]?.name ?? t('partyDropdown.selectParty')}
         <ChevronUpDownIcon fontSize="1.25rem" />
       </ProfileButton>
       <DropdownList variant="long" isExpanded={isMenuOpen}>
@@ -33,7 +40,7 @@ export const PartyDropdown = forwardRef((_: unknown, ref: Ref<PartyDropdownRef>)
           buttonText={t('word.back')}
           buttonIcon={null}
         />
-        <PartyList onOpenMenu={setIsMenuOpen} />
+        <PartyList onOpenMenu={setIsMenuOpen} counterContext={counterContext} />
       </DropdownList>
 
       <Backdrop show={isMenuOpen} onClick={() => setIsMenuOpen(false)} />

--- a/packages/frontend/src/components/PartyDropdown/PartyList.tsx
+++ b/packages/frontend/src/components/PartyDropdown/PartyList.tsx
@@ -2,23 +2,32 @@ import { Fragment, useMemo } from 'react';
 import { useQueryClient } from 'react-query';
 import { useDialogs } from '../../api/useDialogs.tsx';
 import { useParties } from '../../api/useParties.ts';
+import { useSavedSearches } from '../../pages/SavedSearches/useSavedSearches.ts';
 import { Avatar } from '../Avatar';
 import { HorizontalLine } from '../HorizontalLine';
 import { MenuGroupHeader, MenuItem } from '../MenuBar';
+import type { SideBarView } from '../Sidebar/Sidebar.tsx';
 import { type MergedPartyGroup, groupParties, mergeParties } from './mergeParties.ts';
 import styles from './partyDropdown.module.css';
 
 interface PartyListProps {
   onOpenMenu: (value: boolean) => void;
+  counterContext?: SideBarView;
 }
-export const PartyList = ({ onOpenMenu }: PartyListProps) => {
+
+export const PartyList = ({ onOpenMenu, counterContext = 'inbox' }: PartyListProps) => {
   const { parties, setSelectedPartyIds, selectedParties } = useParties();
-  const { dialogs } = useDialogs(parties);
+  const { dialogsByView } = useDialogs(parties);
   const queryClient = useQueryClient();
+  const { savedSearches } = useSavedSearches(selectedParties?.[0]);
 
   const optionsGroups: MergedPartyGroup = useMemo(() => {
-    return groupParties(parties.map((party) => mergeParties(party, dialogs)));
-  }, [parties, dialogs]);
+    return groupParties(
+      parties.map((party) =>
+        mergeParties(party, dialogsByView[counterContext as keyof typeof dialogsByView], savedSearches, counterContext),
+      ),
+    );
+  }, [parties, dialogsByView, savedSearches, counterContext]);
 
   return (
     <>
@@ -44,7 +53,8 @@ export const PartyList = ({ onOpenMenu }: PartyListProps) => {
                     count={option.count}
                     onClick={() => {
                       setSelectedPartyIds(option.onSelectValues);
-                      void queryClient.invalidateQueries({ queryKey: ['dialogs'] });
+                      void queryClient.invalidateQueries(['dialogs']);
+                      void queryClient.invalidateQueries(['savedSearches']);
                       onOpenMenu(false);
                     }}
                   />

--- a/packages/frontend/src/components/PartyDropdown/mergeParties.ts
+++ b/packages/frontend/src/components/PartyDropdown/mergeParties.ts
@@ -1,4 +1,5 @@
-import type { PartyFieldsFragment } from 'bff-types-generated';
+import type { PartyFieldsFragment, SavedSearchesFieldsFragment } from 'bff-types-generated';
+import type { SideBarView } from '../Sidebar';
 
 type Dialog = {
   party: string;
@@ -42,7 +43,14 @@ export function groupParties(mergedParties: MergedParty[]): MergedPartyGroup {
   );
 }
 
-export function mergeParties(party: PartyFieldsFragment, dialogs: Dialog[]): MergedParty {
+export function mergeParties(
+  party: PartyFieldsFragment,
+  dialogs: Dialog[],
+  savedSearches?: SavedSearchesFieldsFragment[],
+  counterContext?: SideBarView,
+): MergedParty {
+  let count = 0;
+
   const mergedParties = party.subParties?.reduce(
     (acc, subParty) => {
       if (subParty.name === party.name) {
@@ -55,12 +63,18 @@ export function mergeParties(party: PartyFieldsFragment, dialogs: Dialog[]): Mer
     [party.party],
   ) ?? [party.party];
 
+  if (counterContext === 'saved-searches') {
+    count = savedSearches?.filter((savedSearch) => savedSearch.data.urn === party.party).length ?? 0;
+  } else {
+    count = dialogs.filter((dialog) => mergedParties.includes(dialog.party)).length;
+  }
+
   return {
     label: party.name,
     isCompany: party.partyType === 'Organization',
     value: party.party,
     onSelectValues: mergedParties,
-    count: dialogs.filter((dialog) => mergedParties.includes(dialog.party)).length,
+    count,
     isCurrentEndUser: party.isCurrentEndUser,
   };
 }

--- a/packages/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar/Sidebar.tsx
@@ -15,7 +15,7 @@ import { HorizontalLine } from '../HorizontalLine/';
 import { MenuItem } from '../MenuBar';
 import styles from './sidebar.module.css';
 
-type SideBarView = InboxViewType | 'saved-searches' | 'archive' | 'deleted';
+export type SideBarView = InboxViewType | 'saved-searches' | 'archive' | 'deleted';
 
 export type ItemPerViewCount = {
   [key in SideBarView]: number;

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -86,7 +86,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
   const [isSavingSearch, setIsSavingSearch] = useState<boolean>(false);
   const [selectedSortOrder, setSelectedSortOrder] = useState<SortingOrder>('created_desc');
 
-  const { selectedParties } = useParties();
+  const { currentEndUser, selectedParties } = useParties();
   const { searchString } = useSearchString();
   const [initialFilters, setInitialFilters] = useState<Filter[]>([]);
   const [activeFilters, setActiveFilters] = useState<Filter[]>([]);
@@ -163,9 +163,11 @@ export const Inbox = ({ viewType }: InboxProps) => {
   }, [itemsToDisplay, shouldShowSearchResults]);
 
   const handleSaveSearch = async () => {
+    console.log('handleSaveSearch currentEndUser', currentEndUser);
     try {
       const data: SavedSearchData = {
         filters: activeFilters as SearchDataValueFilter[],
+        urn: currentEndUser as string | undefined,
         searchString,
         fromView: Routes[viewType],
       };
@@ -219,7 +221,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
         <section className={styles.filtersArea}>
           <div className={styles.gridContainer}>
             <div className={styles.filterSaveContainer}>
-              <PartyDropdown />
+              <PartyDropdown counterContext={viewType} />
             </div>
           </div>
         </section>
@@ -233,7 +235,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
       <section className={styles.filtersArea}>
         <div className={styles.gridContainer}>
           <div className={styles.filterSaveContainer}>
-            <PartyDropdown />
+            <PartyDropdown counterContext={viewType} />
             <FilterBar
               ref={filterBarRef}
               settings={filterBarSettings}

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesPage.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesPage.tsx
@@ -1,6 +1,8 @@
 import type { SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useParties } from '../../api/useParties.ts';
+import { PartyDropdown } from '../../components/PartyDropdown/PartyDropdown.tsx';
 import { useFormatDistance } from '../../i18n/useDateFnsLocale.tsx';
 import { ConfirmDeleteDialog, type DeleteSearchDialogRef } from './ConfirmDeleteDialog/ConfirmDeleteDialog.tsx';
 import {
@@ -18,8 +20,10 @@ export const SavedSearchesPage = () => {
   const [selectedSavedSearch, setSelectedSavedSearch] = useState<SavedSearchesFieldsFragment | null>(null);
   const [selectedDeleteItem, setSelectedDeleteItem] = useState<number | undefined>(undefined);
   const { t } = useTranslation();
-  const { data, isLoading: isLoadingSavedSearches } = useSavedSearches();
-  const savedSearches = data?.savedSearches as SavedSearchesFieldsFragment[];
+  const { selectedParties } = useParties();
+  const { currentPartySavedSearches: savedSearches, isLoading: isLoadingSavedSearches } = useSavedSearches(
+    selectedParties?.[0],
+  );
   const deleteDialogRef = useRef<DeleteSearchDialogRef>(null);
   const editSavedSearchDialogRef = useRef<EditSavedSearchDialogRef>(null);
   const formatDistance = useFormatDistance();
@@ -32,6 +36,13 @@ export const SavedSearchesPage = () => {
   if (!savedSearches?.length) {
     return (
       <main>
+        <section className={styles.filtersArea}>
+          <div className={styles.gridContainer}>
+            <div className={styles.filterSaveContainer}>
+              <PartyDropdown counterContext="saved-searches" />
+            </div>
+          </div>
+        </section>
         <section className={styles.savedSearchesWrapper}>
           <div className={styles.title}>{t('savedSearches.title', { count: 0 })}</div>
           <span>{t('savedSearches.noSearchesFound')}</span>
@@ -42,34 +53,43 @@ export const SavedSearchesPage = () => {
 
   return (
     <main>
-      <section className={styles.savedSearchesWrapper}>
-        <div className={styles.title}>{t('savedSearches.title', { count: savedSearches.length })}</div>
-        <div className={styles.savedSearchesList}>
-          {savedSearches.map((savedSearch, index) => (
-            <SavedSearchesItem
-              key={savedSearch?.id}
-              savedSearch={savedSearch}
-              isLast={index === savedSearches.length - 1}
-              actionPanel={
-                <SaveSearchesActions
-                  key={savedSearch.id}
-                  onEditBtnClick={(selectedValue: SavedSearchesFieldsFragment) => {
-                    setSelectedSavedSearch(selectedValue);
-                    editSavedSearchDialogRef.current?.openDialog();
-                  }}
-                  onDeleteBtnClick={(savedSearchToDelete: SavedSearchesFieldsFragment) => {
-                    setSelectedDeleteItem(savedSearchToDelete.id);
-                    deleteDialogRef.current?.openDialog();
-                  }}
-                  savedSearch={savedSearch}
-                />
-              }
-            />
-          ))}
+      <section className={styles.filtersArea}>
+        <div className={styles.gridContainer}>
+          <div className={styles.filterSaveContainer}>
+            <PartyDropdown counterContext="saved-searches" />
+          </div>
         </div>
-        <div className={styles.lastUpdated}>
-          {t('savedSearches.lastUpdated')}
-          {autoFormatRelativeTime(lastUpdated, formatDistance)}
+      </section>
+      <section>
+        <div className={styles.savedSearchesWrapper}>
+          <div className={styles.title}>{t('savedSearches.title', { count: savedSearches.length })}</div>
+          <div className={styles.savedSearchesList}>
+            {savedSearches.map((savedSearch, index) => (
+              <SavedSearchesItem
+                key={savedSearch?.id}
+                savedSearch={savedSearch}
+                isLast={index === savedSearches.length - 1}
+                actionPanel={
+                  <SaveSearchesActions
+                    key={savedSearch.id}
+                    onEditBtnClick={(selectedValue: SavedSearchesFieldsFragment) => {
+                      setSelectedSavedSearch(selectedValue);
+                      editSavedSearchDialogRef.current?.openDialog();
+                    }}
+                    onDeleteBtnClick={(savedSearchToDelete: SavedSearchesFieldsFragment) => {
+                      setSelectedDeleteItem(savedSearchToDelete.id);
+                      deleteDialogRef.current?.openDialog();
+                    }}
+                    savedSearch={savedSearch}
+                  />
+                }
+              />
+            ))}
+          </div>
+          <div className={styles.lastUpdated}>
+            {t('savedSearches.lastUpdated')}
+            {autoFormatRelativeTime(lastUpdated, formatDistance)}
+          </div>
         </div>
       </section>
       <EditSavedSearchDialog

--- a/packages/frontend/src/pages/SavedSearches/savedSearchesPage.module.css
+++ b/packages/frontend/src/pages/SavedSearches/savedSearchesPage.module.css
@@ -4,6 +4,32 @@
   margin-top: 1.5rem;
 }
 
+.filtersArea {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 1.25rem;
+
+  @media (max-width: 1024px) {
+    padding: 1.5rem;
+  }
+}
+
+.gridContainer {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  width: 100%;
+  align-items: flex-start;
+}
+
+.filterSaveContainer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
 .savedSearchesList {
   background: #fff;
   border-radius: 4px;

--- a/packages/frontend/src/pages/SavedSearches/useSavedSearches.ts
+++ b/packages/frontend/src/pages/SavedSearches/useSavedSearches.ts
@@ -1,5 +1,19 @@
-import type { SavedSearchesQuery } from 'bff-types-generated';
+import type { PartyFieldsFragment, SavedSearchesFieldsFragment, SavedSearchesQuery } from 'bff-types-generated';
 import { useQuery } from 'react-query';
 import { fetchSavedSearches } from '../../api/queries.ts';
 
-export const useSavedSearches = () => useQuery<SavedSearchesQuery, Error>('savedSearches', fetchSavedSearches);
+interface UseSavedSearchesOutput {
+  savedSearches: SavedSearchesFieldsFragment[];
+  isSuccess: boolean;
+  isLoading: boolean;
+  currentPartySavedSearches: SavedSearchesFieldsFragment[] | undefined;
+}
+
+export const useSavedSearches = (currentParty?: PartyFieldsFragment): UseSavedSearchesOutput => {
+  const { data, isLoading, isSuccess } = useQuery<SavedSearchesQuery>('savedSearches', fetchSavedSearches);
+  const savedSearchesUnfiltered = data?.savedSearches as SavedSearchesFieldsFragment[];
+  const currentPartySavedSearches =
+    currentParty && savedSearchesUnfiltered?.filter((savedSearch) => savedSearch?.data?.urn === currentParty.party);
+
+  return { savedSearches: savedSearchesUnfiltered, isLoading, isSuccess, currentPartySavedSearches };
+};


### PR DESCRIPTION
- Searches now being saved per party. 
- Party dropdown and sidebar reflects actual per party count.
- Added party dropdown button to all inboxes.

![CleanShot 2024-08-23 at 10 26 17](https://github.com/user-attachments/assets/b297f104-02aa-4b94-a1b4-97badf68f4cb)



<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->