### PR TITLE
feat:  Activity history for dialog detail page

### DIFF
--- a/packages/bff-types-generated/queries/dialog.fragment.graphql
+++ b/packages/bff-types-generated/queries/dialog.fragment.graphql
@@ -127,14 +127,19 @@ fragment AttachmentFields on Attachment {
 }
 
 fragment DialogActivity on Activity {
-    id
-    type
-    createdAt
-    performedBy {
-      actorType
-      actorId
-      actorName
-    }
+  id
+  performedBy {
+    actorType
+    actorId
+    actorName
+  }
+  description {
+    value
+    languageCode
+  }
+  type
+  createdAt
+  relatedActivityId
 }
 
 fragment SeenLogFields on SeenLog {

--- a/packages/frontend/src/api/organisations.ts
+++ b/packages/frontend/src/api/organisations.ts
@@ -83,7 +83,7 @@ const organisations: OrganisationBody = {
         nb: 'Digitaliseringsdirektoratet',
         nn: 'Digitaliseringsdirektoratet',
       },
-      logo: 'https://altinncdn.no/orgs/dsb/dsb.png',
+      logo: '',
       orgnr: '991825827',
       homepage: 'https://www.digdir.no',
       environments: ['tt02', 'production'],

--- a/packages/frontend/src/api/useDialogById.tsx
+++ b/packages/frontend/src/api/useDialogById.tsx
@@ -1,6 +1,7 @@
 import { ClockIcon, EyeIcon } from '@navikt/aksel-icons';
 import type {
   AttachmentFieldsFragment,
+  DialogActivityFragment,
   DialogByIdFieldsFragment,
   GetDialogByIdQuery,
   PartyFieldsFragment,
@@ -29,9 +30,15 @@ interface MainContentReference {
   mediaType: 'markdown' | 'html' | 'unknown';
 }
 
+export interface DialogActivity {
+  id: string;
+  type: DialogActivityFragment['type'];
+  createdAt: string;
+  description: string;
+  performedBy: DialogActivityFragment['performedBy'];
+}
 export interface DialogByIdDetails {
-  toLabel: string;
-  description: string | React.ReactNode;
+  description: string;
   sender: Participant;
   receiver: Participant;
   title: string;
@@ -41,6 +48,7 @@ export interface DialogByIdDetails {
   attachments: AttachmentFieldsFragment[];
   dialogToken: string;
   mainContentReference?: MainContentReference;
+  activities: DialogActivity[];
 }
 
 interface UseDialogByIdOutput {
@@ -120,7 +128,6 @@ export function mapDialogDtoToInboxItem(
   return {
     title: getPropertyByCultureCode(titleObj),
     description: getPropertyByCultureCode(summaryObj),
-    toLabel: i18n.t('word.to'), // TODO: Remove this
     sender: {
       name: serviceOwner?.name ?? '',
       isCompany: true,
@@ -146,6 +153,15 @@ export function mapDialogDtoToInboxItem(
     attachments: item.attachments.filter((attachment) => attachment.urls.length > 0),
     mainContentReference: getMainContentReference(mainContentReference),
     dialogToken: item.dialogToken!,
+    activities: item.activities
+      .map((activity) => ({
+        id: activity.id,
+        type: activity.type,
+        createdAt: activity.createdAt,
+        performedBy: activity.performedBy,
+        description: getPropertyByCultureCode(activity.description),
+      }))
+      .reverse(),
   };
 }
 export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseDialogByIdOutput => {

--- a/packages/frontend/src/api/useDialogs.tsx
+++ b/packages/frontend/src/api/useDialogs.tsx
@@ -65,7 +65,6 @@ export function mapDialogDtoToInboxItem(
       date: item.createdAt ?? '',
       createdAt: item.createdAt ?? '',
       status: item.status ?? 'UnknownStatus',
-      isModifiedLastByServiceOwner: item.latestActivity?.performedBy === null,
       isSeenByEndUser,
     };
   });

--- a/packages/frontend/src/components/Activity/Activity.tsx
+++ b/packages/frontend/src/components/Activity/Activity.tsx
@@ -1,0 +1,63 @@
+import { ActorType } from 'bff-types-generated';
+import type { DialogActivity, Participant } from '../../api/useDialogById.tsx';
+import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
+import { Avatar } from '../Avatar';
+
+import { t } from 'i18next';
+import styles from './activity.module.css';
+
+interface ActivityProps {
+  activity: DialogActivity;
+  serviceOwner?: Participant;
+}
+
+const getActivityText = (activity: DialogActivity) => {
+  switch (activity.type) {
+    case 'INFORMATION':
+      return activity.description || t('activity.description_missing');
+    case 'PAYMENT_MADE':
+      return t('activity.status.payment_made');
+    case 'SIGNATURE_PROVIDED':
+      return t('activity.status.signature_provided');
+    case 'DIALOG_CREATED':
+      return t('activity.status.dialog_created');
+    case 'DIALOG_CLOSED':
+      return t('activity.status.dialog_closed');
+    case 'TRANSMISSION_OPENED':
+      return t('activity.status.transmission_opened');
+    default:
+      return activity.type;
+  }
+};
+
+export const Activity = ({ activity, serviceOwner }: ActivityProps) => {
+  const format = useFormat();
+  const isCompany =
+    activity.performedBy.actorType === ActorType.ServiceOwner ||
+    (activity.performedBy.actorId ?? '').includes('urn:altinn:organization:');
+  const performedByName = isCompany ? serviceOwner?.name ?? '' : activity.performedBy.actorName ?? '';
+  const imageUrl = isCompany ? serviceOwner?.imageURL : undefined;
+  const text = getActivityText(activity);
+
+  return (
+    <div key={activity.id}>
+      <div className={styles.activityParticipants}>
+        <div className={styles.sender}>
+          <Avatar
+            name={performedByName}
+            companyName={isCompany ? performedByName : ''}
+            imageUrl={imageUrl}
+            size="small"
+          />
+          <span className={styles.participantLabel}>{performedByName}</span>
+        </div>
+        <span className={styles.dateLabel}>{format(activity.createdAt, 'do MMMM yyyy HH:mm')}</span>
+      </div>
+      <div className={styles.statusSection}>
+        <div className={styles.activityContent}>
+          <span className={styles.activityDescription}>{text}</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/frontend/src/components/Activity/activity.module.css
+++ b/packages/frontend/src/components/Activity/activity.module.css
@@ -1,0 +1,50 @@
+.activityParticipants {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  column-gap: 5px;
+  row-gap: 5px;
+  margin-left: 0.4rem;
+}
+
+.sender {
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  column-gap: 0.5rem;
+  font-weight: 500;
+}
+
+.participantLabel {
+  display: flex;
+  font-size: 1rem;
+  font-weight: 500;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.dateLabel {
+  color: var(--text-neutral-subtle);
+  font-size: 1rem;
+  font-weight: 400;
+}
+
+.activityContent {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1.0625rem 1.0625rem 0 0;
+}
+
+.activityDescription {
+  font-weight: 400;
+  font-size: 1.125rem;
+  height: 100%;
+}
+
+.statusSection {
+  margin-left: 1rem;
+  padding: 0 1.0625rem 1.0625rem;
+  border-left: 4px solid rgba(0, 0, 0, 0.1);
+  margin-top: 1rem;
+}

--- a/packages/frontend/src/components/Activity/index.ts
+++ b/packages/frontend/src/components/Activity/index.ts
@@ -1,0 +1,1 @@
+export { Activity } from './Activity.tsx';

--- a/packages/frontend/src/components/Header/SearchDropdown.tsx
+++ b/packages/frontend/src/components/Header/SearchDropdown.tsx
@@ -59,7 +59,6 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({ showDropdownMenu
                 key={item.id}
                 checkboxValue={item.id}
                 title={item.title}
-                toLabel={t('word.to')}
                 description={item.description}
                 sender={item.sender}
                 receiver={item.receiver}

--- a/packages/frontend/src/components/InboxItem/GuiActions.tsx
+++ b/packages/frontend/src/components/InboxItem/GuiActions.tsx
@@ -105,7 +105,7 @@ const GuiActionButton = ({ actions, dialogToken, onDeleteSuccess }: GuiActionsPr
  */
 export const GuiActions = ({ actions, dialogToken, onDeleteSuccess }: GuiActionProps): JSX.Element => {
   return (
-    <section className={styles.guiActions}>
+    <section className={styles.guiActions} data-id="dialog-gui-actions">
       {actions.map((actionProps) => (
         <GuiActionButton
           key={actionProps.id}

--- a/packages/frontend/src/components/InboxItem/InboxItem.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItem.tsx
@@ -3,17 +3,17 @@ import type { JSX } from 'react';
 import { Link } from 'react-router-dom';
 import { useSelectedDialogs } from '../PageLayout';
 
+import { useTranslation } from 'react-i18next';
 import type { Participant } from '../../api/useDialogById.tsx';
 import { Avatar } from '../Avatar';
-import type { InboxItemMetaField } from '../MetaDataFields/MetaDataFields.tsx';
-import { MetaDataFields } from '../MetaDataFields/MetaDataFields.tsx';
+import type { InboxItemMetaField } from '../MetaDataFields';
+import { MetaDataFields } from '../MetaDataFields';
 import { ProfileCheckbox } from '../ProfileCheckbox';
 import styles from './inboxItem.module.css';
 
 interface InboxItemProps {
   checkboxValue: string;
   title: string;
-  toLabel: string;
   description: string;
   sender: Participant;
   receiver: Participant;
@@ -54,7 +54,6 @@ export const OptionalLinkContent = ({
  * @param {Object} props - The properties passed to the component.
  * @param {string} props.checkboxValue - The value attribute for the checkbox input.
  * @param {string} props.title - The title of the inbox item.
- * @param {string} props.toLabel - The label for "to" for full i18n support.
  * @param {string} props.description - The description or content of the inbox item.
  * @param {Participant} props.sender - The sender of the inbox item, including label and optional icon.
  * @param {Participant} props.receiver - The receiver of the inbox item, including label and optional icon.
@@ -69,7 +68,6 @@ export const OptionalLinkContent = ({
  * <InboxItem
  *   checkboxValue="item1"
  *   title="Meeting Reminder"
- *   toLabel="to"
  *   description="Don't forget the meeting tomorrow at 10am."
  *   sender={{ label: "Alice", icon: <MailIcon /> }}
  *   receiver={{ label: "Bob", icon: <PersonIcon /> }}
@@ -84,7 +82,6 @@ export const InboxItem = ({
   description,
   sender,
   receiver,
-  toLabel,
   metaFields = [],
   onCheckedChange,
   checkboxValue,
@@ -95,6 +92,8 @@ export const InboxItem = ({
   isChecked = false,
 }: InboxItemProps): JSX.Element => {
   const { inSelectionMode } = useSelectedDialogs();
+  const { t } = useTranslation();
+
   const onClick = () => {
     if (inSelectionMode && onCheckedChange) {
       onCheckedChange(!checkboxValue);
@@ -201,7 +200,7 @@ export const InboxItem = ({
               <span>{sender?.name}</span>
             </div>
             <div className={styles.receiver}>
-              <span className={styles.participantLabel}>{`${toLabel} ${receiver?.name}`}</span>
+              <span className={styles.participantLabel}>{`${t('word.to')} ${receiver?.name}`}</span>
             </div>
           </div>
           <p className={styles.description}>{description}</p>

--- a/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
@@ -3,6 +3,7 @@ import { FileIcon } from '@navikt/aksel-icons';
 import { AttachmentUrlConsumer } from 'bff-types-generated';
 import { useTranslation } from 'react-i18next';
 import { type DialogByIdDetails, getPropertyByCultureCode } from '../../api/useDialogById.tsx';
+import { Activity } from '../Activity';
 import { Avatar } from '../Avatar';
 import { MainContentReference } from '../MainContentReference';
 import { GuiActions } from './GuiActions.tsx';
@@ -23,16 +24,16 @@ import styles from './inboxItemDetail.module.css';
  * <InboxItemDetail
  *   dialog={{
  *     title: "Project Update",
- *     description: <p>Here's the latest update on the project...</p>,
- *     sender: { label: "Alice", icon: <PersonIcon /> },
- *     receiver: { label: "Bob", icon: <PersonIcon /> },
- *     toLabel: "to",
+ *     description: "Here's the latest update on the project...",
+ *     sender: { name: "Alice", icon: <PersonIcon /> },
+ *     receiver: { name: "Bob", icon: <PersonIcon /> },
  *     attachment: [{ label: "Project Plan", href: "/path/to/document", mime: "application/pdf" }],
  *     tags: [{ label: "Important", icon: <FlagIcon />, className: "important" }],
  *     guiActions: [{ label: "Approve", onClick: () => alert('Approved') }]
  *   }}
  * />
  */
+
 export const InboxItemDetail = ({
   dialog: {
     title,
@@ -40,12 +41,12 @@ export const InboxItemDetail = ({
     description,
     sender,
     receiver,
-    toLabel,
     guiActions,
     tags = [],
     additionalInfo,
     attachments,
     mainContentReference,
+    activities,
   },
 }: { dialog: DialogByIdDetails }): JSX.Element => {
   const { t } = useTranslation();
@@ -56,29 +57,25 @@ export const InboxItemDetail = ({
 
   return (
     <section className={styles.inboxItemDetail}>
-      <header className={styles.header}>
+      <header className={styles.header} data-id="dialog-header">
         <h1 className={styles.title}>{title}</h1>
       </header>
-      <div className={styles.participants}>
+      <div className={styles.participants} data-id="dialog-sender-receiver">
         <div className={styles.sender}>
           <Avatar name={sender?.name ?? ''} imageUrl={sender?.imageURL} />
           <span className={styles.participantLabel}>{sender?.name}</span>
         </div>
-        <span>{toLabel}</span>
+        <span>{t('word.to')}</span>
         <div className={styles.receiver}>
           <span className={styles.participantLabel}>{receiver?.name}</span>
         </div>
       </div>
-      <section className={styles.descriptionContainer}>
-        {typeof description === 'string' ? (
-          <p className={styles.description}>{description}</p>
-        ) : (
-          <div>{description}</div>
-        )}
-        {mainContentReference && <MainContentReference args={mainContentReference} dialogToken={dialogToken} />}
-        <section>
+      <div className={styles.sectionWithStatus} data-id="dialog-description">
+        <p className={styles.description}>{description}</p>
+        <MainContentReference args={mainContentReference} dialogToken={dialogToken} />
+        <section data-id="dialog-attachments">
           <h2 className={styles.attachmentTitle}>{t('inbox.heading.attachments', { count: attachmentCount })}</h2>
-          <ul className={styles.attachments}>
+          <ul className={styles.attachments} data-id="dialog-attachments-list">
             {attachments.map((attachment) =>
               attachment.urls
                 .filter((url) => url.consumerType === AttachmentUrlConsumer.Gui)
@@ -105,7 +102,7 @@ export const InboxItemDetail = ({
             // TODO: Redirect to inbox
           }}
         />
-        <div className={styles.tags}>
+        <div className={styles.tags} data-id="dialog-meta-field-tags">
           {tags.map((tag) => (
             <div key={tag.label} className={styles.tag}>
               {tag.icon && <div className={styles.tagIcon}>{tag.icon}</div>}
@@ -113,8 +110,18 @@ export const InboxItemDetail = ({
             </div>
           ))}
         </div>
+      </div>
+      {additionalInfo && (
+        <section className={styles.additionalInfo} data-id="dialog-additional-info">
+          {additionalInfo}
+        </section>
+      )}
+      <section data-id="dialog-activity-history" className={styles.activities}>
+        <h3 className={styles.activitiesTitle}>{t('word.activities')}</h3>
+        {activities.map((activity) => (
+          <Activity key={activity.id} activity={activity} serviceOwner={sender} />
+        ))}
       </section>
-      {additionalInfo && <section className={styles.additionalInfo}>{additionalInfo}</section>}
     </section>
   );
 };

--- a/packages/frontend/src/components/InboxItem/inboxItemDetail.module.css
+++ b/packages/frontend/src/components/InboxItem/inboxItemDetail.module.css
@@ -2,10 +2,16 @@
   display: flex;
   flex-direction: column;
   background: #fff;
-  padding: 0.5rem;
+  padding: 1.5rem;
 }
 
-.descriptionContainer {
+@media (max-width: 1024px) {
+  .inboxItemDetail {
+    padding: 0.5rem;
+  }
+}
+
+.sectionWithStatus {
   margin-left: 1rem;
   padding: 0 1.0625rem 1.0625rem;
   border-left: 4px solid rgba(0, 0, 0, 0.1);
@@ -37,9 +43,16 @@
 }
 
 .activities {
-  padding: 2rem 0.5rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
   display: flex;
   flex-direction: column;
+  row-gap: 1.5rem;
+}
+
+.activitiesTitle {
+  font-size: 1.25rem;
+  font-weight: 500;
 }
 
 .participants {
@@ -47,6 +60,7 @@
   align-items: center;
   flex-wrap: wrap;
   column-gap: 5px;
+  row-gap: 5px;
 }
 
 .participantLabel {

--- a/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
+++ b/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
@@ -17,13 +17,17 @@ export const MainContentReference = ({
     enabled: args?.url !== undefined && args?.mediaType === 'markdown',
   });
 
+  if (!args) {
+    return null;
+  }
+
   if (typeof error === 'string') {
-    return <div>Error parsing 'mainContentReference': {error}</div>;
+    return <div data-id="dialog-main-content-reference-error">Error parsing 'mainContentReference': {error}</div>;
   }
 
   if (typeof data === 'string' && isSuccess) {
     return (
-      <section>
+      <section data-id="dialog-main-content-reference">
         <Markdown>{data}</Markdown>
       </section>
     );

--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -1,4 +1,10 @@
 {
+  "activity.description_missing": "Description missing",
+  "activity.status.dialog_closed": "Dialog closed",
+  "activity.status.dialog_created": "Dialog created",
+  "activity.status.payment_made": "Payment made",
+  "activity.status.signature_provided": "Signature provided",
+  "activity.status.transmission_opened": "Transmission opened",
   "actionPanel.buttons.archive": "Move to archive",
   "actionPanel.buttons.delete": "Delete",
   "actionPanel.buttons.mark_as_read": "Mark as read",
@@ -111,6 +117,7 @@
   "sort_order.created_asc": "Oldest first",
   "sort_order.created_desc": "Newest first",
   "word.and": "and",
+  "word.activities": "Activities",
   "word.back": "Back",
   "word.change": "Change",
   "word.close": "Close",

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -1,4 +1,10 @@
 {
+  "activity.description_missing": "Beskrivelse mangler",
+  "activity.status.dialog_closed": "Dialog lukket",
+  "activity.status.dialog_created": "Dialog opprettet",
+  "activity.status.payment_made": "Betaling utført",
+  "activity.status.signature_provided": "Signatur gitt",
+  "activity.status.transmission_opened": "Sending åpnet",
   "actionPanel.buttons.archive": "Flytt til arkiv",
   "actionPanel.buttons.delete": "Slett",
   "actionPanel.buttons.mark_as_read": "Markert som lest",
@@ -111,6 +117,7 @@
   "sort_order.created_asc": "Eldste først",
   "sort_order.created_desc": "Nyeste først",
   "word.and": "og",
+  "word.activities": "Aktiviteter",
   "word.back": "Tilbake",
   "word.change": "Endre",
   "word.close": "Lukk",

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -50,7 +50,6 @@ export interface InboxItemInput {
   date: string;
   createdAt: string;
   status: DialogStatus;
-  isModifiedLastByServiceOwner: boolean;
   isSeenByEndUser: boolean;
 }
 interface DialogCategory {
@@ -328,7 +327,6 @@ export const Inbox = ({ viewType }: InboxProps) => {
                   key={item.id}
                   checkboxValue={item.id}
                   title={item.title}
-                  toLabel={t('word.to')}
                   description={item.description}
                   sender={item.sender}
                   receiver={item.receiver}

--- a/packages/frontend/src/pages/InboxItemPage/inboxItemPageSkeleton.module.css
+++ b/packages/frontend/src/pages/InboxItemPage/inboxItemPageSkeleton.module.css
@@ -2,8 +2,18 @@
   display: flex;
   flex-direction: column;
   background: #fff;
-  padding: 0.5rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+
+  @media screen and (min-width: 600px) {
+    min-width: 550px;
+    max-width: 988px;
+  }
+}
+
+@media screen and (max-width: 1024px) {
+  .itemInboxPage {
+    margin-top: 1.5rem;
+  }
 }
 
 .titleOne {

--- a/packages/storybook/src/stories/InboxItems/InboxItems.stories.tsx
+++ b/packages/storybook/src/stories/InboxItems/InboxItems.stories.tsx
@@ -27,7 +27,6 @@ export const SimpleDesktopExample = () => {
         description="Eksempel på en beskrivelse av en ulest melding"
         sender={{ isCompany: false, name: 'DigDir' }}
         receiver={{ isCompany: false, name: 'Per Person' }}
-        toLabel="til"
         tags={[
           { label: '19.01.2024', icon: <CalendarIcon /> },
           { label: 'Viktig!', icon: <SealIcon /> },
@@ -42,7 +41,6 @@ export const SimpleDesktopExample = () => {
         description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sollicitudin, nisi vitae auctor accumsan, odio ipsum efficitur nulla, eu tempus sem leo et felis. Curabitur vel varius tortor. Proin semper in nisl eget venenatis. Vestibulum egestas urna id sapien iaculis, id consequat ante varius. Vestibulum vel facilisis nulla. Aenean vitae orci est. Nulla at sagittis mauris. Vestibulum nisl nibh, pulvinar non odio quis, fermentum aliquet tortor. Mauris imperdiet ante lacus. Sed pretium, lorem sed ornare vehicula, neque diam dictum massa, et aliquam lectus metus sit amet nunc. Aliquam erat volutpat. Aliquam ac massa mauris"
         sender={{ isCompany: false, name: 'DigDir' }}
         receiver={{ isCompany: false, name: 'Per Person' }}
-        toLabel="til"
         tags={[
           { label: '16.01.2024', icon: <CalendarIcon /> },
           { label: 'Viktig!', icon: <SealIcon /> },
@@ -56,7 +54,6 @@ export const SimpleDesktopExample = () => {
         description="Integer lacinia ornare ex id consequat. Vivamus condimentum ex vitae elit dignissim convallis. Vivamus nec velit lacus. Vestibulum pharetra pharetra nibh vitae auctor."
         sender={{ isCompany: false, name: 'DigDir' }}
         receiver={{ isCompany: false, name: 'Per Person' }}
-        toLabel="til"
         tags={[
           { label: '12.01.2024', icon: <CalendarIcon /> },
           { label: 'Viktig!', icon: <SealIcon /> },


### PR DESCRIPTION
Show activites for dialogs, rendering description value from service owner rawn for type `informations`, othertwise translating the `type`.


![image](https://github.com/user-attachments/assets/0969cf45-30de-480b-83e9-209f4271f22f)



## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->