### PR TITLE
feat: Visual adjustments. Added status, timestamp and other logic to MetaData

### DIFF
--- a/packages/frontend/src/components/InboxItem/InboxItem.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItem.tsx
@@ -5,14 +5,10 @@ import { useSelectedDialogs } from '../PageLayout';
 
 import type { Participant } from '../../api/useDialogById.tsx';
 import { Avatar } from '../Avatar';
+import type { InboxItemTag } from '../MetaDataFields/MetaDataFields.tsx';
+import { MetaDataFields } from '../MetaDataFields/MetaDataFields.tsx';
 import { ProfileCheckbox } from '../ProfileCheckbox';
 import styles from './inboxItem.module.css';
-
-export interface InboxItemTag {
-  label: string;
-  icon?: JSX.Element;
-  className?: string;
-}
 
 interface InboxItemProps {
   checkboxValue: string;
@@ -28,6 +24,7 @@ interface InboxItemProps {
   linkTo?: string;
   isMinimalistic?: boolean;
   onClose?: () => void;
+  isSeenByEndUser?: boolean;
 }
 
 export const OptionalLinkContent = ({
@@ -98,7 +95,7 @@ export const InboxItem = ({
   isChecked = false,
 }: InboxItemProps): JSX.Element => {
   const { inSelectionMode } = useSelectedDialogs();
-
+  console.log('InboxItem', tags);
   const onClick = () => {
     if (inSelectionMode && onCheckedChange) {
       onCheckedChange(!checkboxValue);
@@ -202,22 +199,14 @@ export const InboxItem = ({
                 imageUrl={sender.imageURL}
                 size="small"
               />
-              <span className={styles.participantLabel}>{sender?.name}</span>
+              <span>{sender?.name}</span>
             </div>
-            <span>{toLabel}</span>
             <div className={styles.receiver}>
-              <span className={styles.participantLabel}>{receiver?.name}</span>
+              <span className={styles.participantLabel}>{`${toLabel} ${receiver?.name}`}</span>
             </div>
           </div>
           <p className={styles.description}>{description}</p>
-          <div className={styles.tags}>
-            {tags?.map((tag) => (
-              <div key={tag.label} className={styles.tag}>
-                {tag.icon && <div className={styles.icon}>{tag.icon}</div>}
-                <span> {tag.label}</span>
-              </div>
-            ))}
-          </div>
+          <MetaDataFields tags={tags || []} />
         </section>
       </OptionalLinkContent>
     </li>

--- a/packages/frontend/src/components/InboxItem/inboxItem.module.css
+++ b/packages/frontend/src/components/InboxItem/inboxItem.module.css
@@ -44,7 +44,6 @@
   margin: 1rem 1.0625rem 1.0625rem 1rem;
   padding-left: 1rem;
   border-left: 4px solid rgba(0, 0, 0, 0.1);
-  padding-bottom: 0.5rem;
 }
 
 .minimalistic .inboxItem {
@@ -62,12 +61,12 @@
 }
 
 .title {
-  color: #000;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 25px;
   margin-top: 0;
-  margin-bottom: 0;
-  font-size: 1.25rem;
-  font-weight: 500;
-  line-height: 2;
+  margin-bottom: 0.25rem;
 }
 
 .minimalistic .title {
@@ -86,6 +85,10 @@
   flex-wrap: wrap;
   align-items: center;
   column-gap: 5px;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 20px;
 }
 
 .receiver,
@@ -100,10 +103,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-}
-
-.sender {
-  font-weight: 500;
+  font-weight: 400;
 }
 
 .senderIcon {
@@ -121,18 +121,6 @@
   }
 }
 
-.icon {
-  margin-right: 0.375em;
-  height: 16px;
-  width: 16px;
-  flex-shrink: 0;
-
-  > svg {
-    min-width: 100%;
-    min-height: 100%;
-  }
-}
-
 .description {
   color: #000;
   font-size: 1rem;
@@ -141,7 +129,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 0.5rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 }
 
 .minimalistic .description {
@@ -150,19 +139,6 @@
   font-style: normal;
   margin: 0;
   padding: 0;
-}
-
-.tags {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.tag {
-  display: flex;
-  align-items: center;
-  margin-right: 1rem;
-  font-weight: 400;
 }
 
 .pointer {

--- a/packages/frontend/src/components/MetaDataFields/MetaDataField.tsx
+++ b/packages/frontend/src/components/MetaDataFields/MetaDataField.tsx
@@ -1,0 +1,30 @@
+import { ClockIcon, EyeIcon, PaperclipIcon } from '@navikt/aksel-icons';
+import cx from 'classnames';
+import type { InboxItemTag } from './MetaDataFields';
+import styles from './metaDataFields.module.css';
+
+export const MetaDataField = ({ tag }: { tag: InboxItemTag }) => {
+  const getIconByType = (type: InboxItemTag['type']) => {
+    switch (type) {
+      case 'attachment':
+        return <PaperclipIcon />;
+      case 'timestamp':
+        return <ClockIcon />;
+      case 'seenBy':
+        return <EyeIcon />;
+      case 'status':
+        return;
+    }
+  };
+  const icon = getIconByType(tag.type);
+
+  return (
+    <div
+      className={cx(styles.tag, { [styles.status]: tag.type === 'status' })}
+      title={String(tag.options?.tooltip || '')}
+    >
+      {icon && <div className={styles.icon}>{icon}</div>}
+      <span>{tag.label}</span>
+    </div>
+  );
+};

--- a/packages/frontend/src/components/MetaDataFields/MetaDataFields.tsx
+++ b/packages/frontend/src/components/MetaDataFields/MetaDataFields.tsx
@@ -1,0 +1,20 @@
+import { MetaDataField } from './MetaDataField.tsx';
+import styles from './metaDataFields.module.css';
+
+export interface InboxItemTag {
+  type: 'attachment' | 'status' | 'timestamp' | 'seenBy';
+  label: string;
+  options?: {
+    [propKey: string]: string | number | boolean;
+  };
+}
+
+export const MetaDataFields = ({ tags }: { tags: InboxItemTag[] }) => {
+  return (
+    <div className={styles.tags}>
+      {tags.map((tag, index) => (
+        <MetaDataField key={`tag-${index}`} tag={tag} />
+      ))}
+    </div>
+  );
+};

--- a/packages/frontend/src/components/MetaDataFields/index.ts
+++ b/packages/frontend/src/components/MetaDataFields/index.ts
@@ -1,0 +1,2 @@
+export * from './MetaDataFields.tsx';
+export * from './MetaDataField.tsx';

--- a/packages/frontend/src/components/MetaDataFields/metaDataFields.module.css
+++ b/packages/frontend/src/components/MetaDataFields/metaDataFields.module.css
@@ -1,0 +1,30 @@
+.status {
+  border: 1px solid #b8bcc1;
+  border-radius: 2px;
+  padding: 0.25rem;
+}
+
+.tags {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.tag {
+  display: flex;
+  align-items: center;
+  margin-right: 1rem;
+  font-weight: 400;
+}
+
+.icon {
+  margin-right: 0.375em;
+  height: 16px;
+  width: 16px;
+  flex-shrink: 0;
+
+  > svg {
+    min-width: 100%;
+    min-height: 100%;
+  }
+}

--- a/packages/frontend/src/components/index.ts
+++ b/packages/frontend/src/components/index.ts
@@ -13,3 +13,4 @@ export * from './Snackbar';
 export * from './HorizontalLine';
 export * from './Avatar';
 export * from './Badge';
+export * from './MetaDataFields';

--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -110,6 +110,7 @@
   "sort_order.choose.label": "Sort by",
   "sort_order.created_asc": "Oldest first",
   "sort_order.created_desc": "Newest first",
+  "word.and": "and",
   "word.back": "Back",
   "word.change": "Change",
   "word.close": "Close",
@@ -120,8 +121,12 @@
   "word.log_out": "Log Out",
   "word.main_menu": "Main Menu",
   "word.menu": "Menu",
+  "word.others": "others",
   "word.private": "Private",
   "word.search": "Search",
   "word.seen": "Seen",
-  "word.to": "to"
+  "word.seenBy": "Seen by",
+  "word.status": "Status",
+  "word.to": "to",
+  "word.you": "you"
 }

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -110,6 +110,7 @@
   "sort_order.choose.label": "Sorter etter",
   "sort_order.created_asc": "Eldste først",
   "sort_order.created_desc": "Nyeste først",
+  "word.and": "og",
   "word.back": "Tilbake",
   "word.change": "Endre",
   "word.close": "Lukk",
@@ -120,8 +121,12 @@
   "word.log_out": "Logg ut",
   "word.main_menu": "Hovedmeny",
   "word.menu": "Meny",
+  "word.others": "andre",
   "word.private": "Privat",
   "word.search": "Søk",
   "word.seen": "Sett",
-  "word.to": "til"
+  "word.seenBy": "Sett av",
+  "word.status": "Status",
+  "word.to": "til",
+  "word.you": "deg"
 }

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -8,14 +8,8 @@ import { createSavedSearch } from '../../api/queries.ts';
 import type { Participant } from '../../api/useDialogById.tsx';
 import { type InboxViewType, getViewType, useDialogs, useSearchDialogs } from '../../api/useDialogs.tsx';
 import { useParties } from '../../api/useParties.ts';
-import {
-  ActionPanel,
-  InboxItem,
-  type InboxItemTag,
-  InboxItems,
-  SortOrderDropdown,
-  useSearchString,
-} from '../../components';
+import { ActionPanel, InboxItem, InboxItems, SortOrderDropdown, useSearchString } from '../../components';
+import type { InboxItemTag } from '../../components';
 import { type Filter, FilterBar } from '../../components';
 import { useSelectedDialogs } from '../../components';
 import { useSnackbar } from '../../components';

--- a/packages/storybook/src/stories/MetaDataFields/metaDataFields.stories.ts
+++ b/packages/storybook/src/stories/MetaDataFields/metaDataFields.stories.ts
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MetaDataFields } from 'frontend';
+
+export default {
+  title: 'Components/MetaDataFields',
+  component: MetaDataFields,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as Meta<typeof MetaDataFields>;
+
+export const Default: StoryObj<typeof MetaDataFields> = {
+  args: {
+    tags: [
+      { type: 'status', label: 'Status' },
+      { type: 'timestamp', label: 'Timestamp' },
+      { type: 'attachment', label: 'Attachment here' },
+      {
+        type: 'seenBy',
+        label: 'Seen By You',
+        options: { tooltip: 'This is seen by \n Every person will be listed here' },
+      },
+    ],
+  },
+};


### PR DESCRIPTION
1. Visual adjustments (needs more spacing and adjustments to font-size)
2. Add field status (display dialog.status raw)
3. Add timestamp to modified date
4. Remove the word attachment from label for attachments
5. Add + {countOfOthers} for dialogs seen by others than current end user.
6. Add storybook entry

![CleanShot 2024-09-02 at 13 22 34](https://github.com/user-attachments/assets/a857408e-d9cf-49d0-a8fa-31100f3e1a34)


<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->