### PR TITLE
fix: replace companyName with profile in Avatar

### DIFF
--- a/packages/frontend/src/api/useParties.ts
+++ b/packages/frontend/src/api/useParties.ts
@@ -1,4 +1,5 @@
 import type { PartiesQuery, PartyFieldsFragment } from 'bff-types-generated';
+import { useMemo } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
 import { toTitleCase } from '../profile';
 import { graphQLSDK } from './queries.ts';
@@ -61,16 +62,24 @@ export const useParties = (): UsePartiesOutput => {
     setSelectedParties(data?.parties.filter((party) => partyIds.includes(party.party)) ?? []);
   };
 
+  const selectedParties = getSelectedParties();
+  const allOrganizationsSelected = useMemo(() => {
+    const allOrgParties = data?.parties.filter((party) => party.partyType === 'Organization') ?? [];
+    const selectedOrgParties = selectedParties.filter((party) => party.partyType === 'Organization');
+
+    return selectedOrgParties.length > 0 && allOrgParties.length === selectedOrgParties.length;
+  }, [selectedParties, data]);
+
   return {
     isLoading,
     isSuccess,
-    selectedParties: getSelectedParties(),
-    selectedPartyIds: getSelectedParties().map((party) => party.party) ?? [],
+    selectedParties,
+    selectedPartyIds: selectedParties.map((party) => party.party) ?? [],
     setSelectedParties,
     setSelectedPartyIds,
     parties: data?.parties ?? [],
     currentEndUser: data?.parties.find((party) => party.isCurrentEndUser),
     deletedParties: data?.deletedParties ?? [],
-    allOrganizationsSelected: getSelectedParties().every((party) => party.partyType === 'Organization'),
+    allOrganizationsSelected,
   };
 };

--- a/packages/frontend/src/components/Activity/Activity.tsx
+++ b/packages/frontend/src/components/Activity/Activity.tsx
@@ -45,7 +45,7 @@ export const Activity = ({ activity, serviceOwner }: ActivityProps) => {
         <div className={styles.sender}>
           <Avatar
             name={performedByName}
-            companyName={isCompany ? performedByName : ''}
+            profile={isCompany ? 'organization' : 'person'}
             imageUrl={imageUrl}
             size="small"
           />

--- a/packages/frontend/src/components/Avatar/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar/Avatar.tsx
@@ -3,22 +3,30 @@ import { useState } from 'react';
 import { fromStringToColor } from '../../profile';
 import styles from './avatar.module.css';
 
+export type AvatarProfile = 'organization' | 'person';
+
 interface AvatarProps {
   name: string;
-  companyName?: string;
+  profile?: AvatarProfile;
   className?: string;
   imageUrl?: string;
   imageUrlAlt?: string;
   size?: 'small' | 'medium';
 }
 
-export const Avatar = ({ name, companyName, className, size = 'medium', imageUrl, imageUrlAlt }: AvatarProps) => {
+export const Avatar = ({
+  name,
+  className,
+  size = 'medium',
+  profile = 'person',
+  imageUrl,
+  imageUrlAlt,
+}: AvatarProps) => {
   const [hasImageError, setHasImageError] = useState<boolean>(false);
-  const appliedName = companyName || name || '';
-  const isOrganization = !!companyName;
-  const colorType = isOrganization ? 'dark' : 'light';
-  const { backgroundColor, foregroundColor } = fromStringToColor(appliedName, colorType);
-  const initials = (appliedName[0] ?? '').toUpperCase();
+  const isOrganization = profile === 'organization';
+  const colorSchema = isOrganization ? 'dark' : 'light';
+  const { backgroundColor, foregroundColor } = fromStringToColor(name, colorSchema);
+  const initials = (name[0] ?? '').toUpperCase();
   const usingImageUrl = imageUrl && !hasImageError;
   const initialStyles = !usingImageUrl
     ? {

--- a/packages/frontend/src/components/GlobalMenuBar/GlobalMenuBar.tsx
+++ b/packages/frontend/src/components/GlobalMenuBar/GlobalMenuBar.tsx
@@ -2,7 +2,7 @@ import { XMarkIcon } from '@navikt/aksel-icons';
 import cx from 'classnames';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Avatar } from '../Avatar';
+import { Avatar, type AvatarProfile } from '../Avatar';
 import { Backdrop } from '../Backdrop';
 import { Badge } from '../Badge';
 import { NavigationDropdownMenu } from './NavigationDropdownMenu.tsx';
@@ -11,7 +11,7 @@ import styles from './globalMenuBar.module.css';
 
 interface GlobalMenuBarProps {
   name: string;
-  companyName?: string;
+  profile: AvatarProfile;
   className?: string;
   notificationCount?: number;
 }
@@ -24,12 +24,7 @@ export const CloseMenuButton = ({ className }: { className?: string }) => {
   );
 };
 
-export const GlobalMenuBar: React.FC<GlobalMenuBarProps> = ({
-  name,
-  companyName,
-  notificationCount = 0,
-  className,
-}) => {
+export const GlobalMenuBar: React.FC<GlobalMenuBarProps> = ({ name, profile, notificationCount = 0, className }) => {
   const [showBackDrop, setShowBackDrop] = useState<boolean>(false);
   const [showSubMenu, setShowSubMenu] = useState<SubMenuSelection>('none');
 
@@ -52,11 +47,7 @@ export const GlobalMenuBar: React.FC<GlobalMenuBarProps> = ({
           <div className={cx(styles.menuText, className)} aria-hidden="true">
             <div className={styles.nameWithInitials}>
               {t('word.menu')}
-              {showBackDrop ? (
-                <CloseMenuButton className={className} />
-              ) : (
-                <Avatar name={name} companyName={companyName} />
-              )}
+              {showBackDrop ? <CloseMenuButton className={className} /> : <Avatar name={name} profile={profile} />}
             </div>
           </div>
           {showNotificationsBadge && (
@@ -68,7 +59,7 @@ export const GlobalMenuBar: React.FC<GlobalMenuBarProps> = ({
         <NavigationDropdownMenu
           showDropdownMenu={showBackDrop}
           name={name}
-          companyName={companyName}
+          profile={profile}
           onClose={handleClose}
           showSubMenu={showSubMenu}
           setShowSubMenu={setShowSubMenu}

--- a/packages/frontend/src/components/GlobalMenuBar/NavigationDropdownMenu.tsx
+++ b/packages/frontend/src/components/GlobalMenuBar/NavigationDropdownMenu.tsx
@@ -1,7 +1,7 @@
 import { InboxFillIcon, MenuGridIcon, PersonChatIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { MenuItem } from '../MenuBar';
-import { HorizontalLine } from '../index.ts';
+import { type AvatarProfile, HorizontalLine } from '../index.ts';
 import { MenuLogoutButton } from './MenuLogoutButton.tsx';
 import { NavigationDropdownSubMenu, type SubMenuSelection } from './NavigationDropdownSubMenu.tsx';
 import { UserInfo } from './UserInfo.tsx';
@@ -10,7 +10,7 @@ import styles from './navigationDropdownMenu.module.css';
 interface NavigationDropdownMenuProps {
   showDropdownMenu: boolean;
   name: string;
-  companyName?: string;
+  profile: AvatarProfile;
   onClose: () => void;
   showSubMenu: SubMenuSelection;
   setShowSubMenu: (showSubMenu: SubMenuSelection) => void;
@@ -19,7 +19,7 @@ interface NavigationDropdownMenuProps {
 export const NavigationDropdownMenu: React.FC<NavigationDropdownMenuProps> = ({
   showDropdownMenu,
   name,
-  companyName,
+  profile,
   onClose,
   showSubMenu,
   setShowSubMenu,
@@ -45,7 +45,7 @@ export const NavigationDropdownMenu: React.FC<NavigationDropdownMenuProps> = ({
   return (
     <div className={styles.menuItems}>
       <ul className={styles.menuList}>
-        <UserInfo name={name} companyName={companyName} onClick={() => setShowSubMenu('profile')} />
+        <UserInfo name={name} profile={profile} onClick={() => setShowSubMenu('profile')} />
         <HorizontalLine />
         <MenuItem
           displayText={t('sidebar.inbox')}

--- a/packages/frontend/src/components/GlobalMenuBar/UserInfo.tsx
+++ b/packages/frontend/src/components/GlobalMenuBar/UserInfo.tsx
@@ -1,17 +1,17 @@
 import { ChevronRightIcon } from '@navikt/aksel-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { Avatar } from '../Avatar';
+import { Avatar, type AvatarProfile } from '../Avatar';
 import { MenuItem } from '../MenuBar';
 import styles from './userInfo.module.css';
 
 interface UserInfoProps {
   name: string;
-  companyName?: string;
+  profile: AvatarProfile;
   onClick: () => void;
 }
 
-export const UserInfo = ({ name, companyName, onClick }: UserInfoProps) => {
+export const UserInfo = ({ name, profile, onClick }: UserInfoProps) => {
   const { t } = useTranslation();
   return (
     <MenuItem
@@ -24,11 +24,8 @@ export const UserInfo = ({ name, companyName, onClick }: UserInfoProps) => {
           role="button"
           tabIndex={0}
         >
-          <Avatar name={name} companyName={companyName} />
-          <div>
-            <div className={styles.primaryName}>{companyName || name}</div>
-            <div className={styles.secondaryName}>{companyName ? name : t('word.private')}</div>
-          </div>
+          <Avatar name={name} profile={profile} />
+          <div className={styles.primaryName}>{name}</div>
         </MenuItem.LeftContent>
       }
       rightContent={

--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useWindowSize } from '../../../utils/useWindowSize.tsx';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/queryParams';
+import type { AvatarProfile } from '../Avatar';
 import { GlobalMenuBar } from '../GlobalMenuBar/GlobalMenuBar.tsx';
 import { AltinnLogo } from './AltinnLogo';
 import { SearchBar } from './SearchBar';
@@ -11,7 +12,7 @@ import styles from './header.module.css';
 
 type HeaderProps = {
   name: string;
-  companyName?: string;
+  profile: AvatarProfile;
   notificationCount?: number;
 };
 
@@ -44,27 +45,27 @@ export const useSearchString = () => {
  * company association, and an optional notification count. The search bar is hidden on mobile.
  *
  * @component
- * @param {string} props.name - User's name.
- * @param {string} [props.companyName] - Associated company name, if applicable.
+ * @param {string} props.name - Name of selected party.
+ * @param {AvatarProfile} [props.profile] - Profile.
  * @param {number} [props.notificationCount] - Optional count of notifications to display.
  * @returns {JSX.Element} The Header component.
  *
  * @example
  * <Header
  *  name="Ola Nordmann"
- *  companyName="Aker Solutions AS"
+ *  profile="person"
  *  notificationCount={3}
  * />
  */
 
-export const Header: React.FC<HeaderProps> = ({ name, companyName, notificationCount }) => {
+export const Header: React.FC<HeaderProps> = ({ name, profile, notificationCount }) => {
   const { isTabletOrSmaller } = useWindowSize();
   return (
     <header data-testid="main-header">
       <nav className={styles.navigation} aria-label="Navigasjon">
         <AltinnLogo className={styles.logo} />
         {!isTabletOrSmaller && <SearchBar />}
-        <GlobalMenuBar notificationCount={notificationCount} name={name} companyName={companyName} />
+        <GlobalMenuBar notificationCount={notificationCount} name={name} profile={profile} />
       </nav>
       {isTabletOrSmaller && <SearchBar />}
     </header>

--- a/packages/frontend/src/components/Header/SearchDropdown.tsx
+++ b/packages/frontend/src/components/Header/SearchDropdown.tsx
@@ -39,8 +39,8 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({ showDropdownMenu
       <ul className={styles.menuList}>
         <SearchDropdownItem onClick={() => onSearch(searchValue)} horizontalLine>
           <div className={styles.displayText}>
-            {searchValue?.length > 2 ? <span className={styles.searchTermText}>{`«${searchValue}»`}</span> : 'Alt'} i
-            innboks
+            {searchValue?.length > 2 ? <span className={styles.searchTermText}>{`«${searchValue}»`}</span> : 'Alt'}{' '}
+            {t('search.title.in_inbox')}
           </div>
           <div className={styles.rightContent}>
             <span className={styles.keyText}>Return</span>
@@ -70,7 +70,7 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({ showDropdownMenu
                 <span className={styles.timeSince}>{autoFormatRelativeTime(new Date(item.date), formatDistance)}</span>
                 <Avatar
                   name={item.sender.name}
-                  companyName={item.sender.isCompany ? item.sender.name : ''}
+                  profile={item.sender.isCompany ? 'organization' : 'person'}
                   imageUrl={item.sender.imageURL}
                   size="small"
                 />

--- a/packages/frontend/src/components/InboxItem/InboxItem.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItem.tsx
@@ -196,7 +196,7 @@ export const InboxItem = ({
             <div className={styles.sender}>
               <Avatar
                 name={sender?.name ?? ''}
-                companyName={sender?.isCompany ? sender?.name : ''}
+                profile={sender?.isCompany ? 'organization' : 'person'}
                 imageUrl={sender.imageURL}
                 size="small"
               />

--- a/packages/frontend/src/components/PartyDropdown/PartyList.tsx
+++ b/packages/frontend/src/components/PartyDropdown/PartyList.tsx
@@ -77,7 +77,6 @@ export const PartyList = ({ optionsGroups, selectedPartyIds, onSelect, showSearc
             <Fragment key={key}>
               <MenuGroupHeader title={group.title} />
               {group.parties.map((option) => {
-                const companyName = option.isCompany ? option.label : '';
                 const isSelected = !!(
                   selectedPartyIds.length &&
                   selectedPartyIds.length === option.onSelectValues.length &&
@@ -90,7 +89,11 @@ export const PartyList = ({ optionsGroups, selectedPartyIds, onSelect, showSearc
                       isActive={isSelected}
                       leftContent={
                         <MenuItem.LeftContent>
-                          <Avatar name={option.label} companyName={companyName} size="small" />
+                          <Avatar
+                            name={option.label}
+                            profile={option.isCompany ? 'organization' : 'person'}
+                            size="small"
+                          />
                           <span className={styles.partyListLabel}>{option.label}</span>
                         </MenuItem.LeftContent>
                       }

--- a/packages/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar/Sidebar.tsx
@@ -22,7 +22,6 @@ export type ItemPerViewCount = {
 };
 export interface SidebarProps {
   itemsPerViewCount: ItemPerViewCount;
-  isCompany?: boolean;
 }
 
 /**
@@ -32,7 +31,6 @@ export interface SidebarProps {
  *
  * @param {SidebarProps} props - The props for the Sidebar component.
  * @param {ItemPerViewCount} props.itemsPerViewCount - An object containing the count of items for each view.
- * @param {boolean} [props.isCompany] - Optional flag to indicate if the sidebar is being used in a company context.
  *
  * @returns {React.ReactElement} The rendered Sidebar component.
  *

--- a/packages/storybook/src/stories/Avatar/avatar.stories.tsx
+++ b/packages/storybook/src/stories/Avatar/avatar.stories.tsx
@@ -28,7 +28,8 @@ type Story = StoryObj<typeof Avatar>;
 
 export const ImageURL: Story = {
   args: {
-    companyName: 'NAV',
+    profile: 'organization',
+    name: 'NAV',
     imageUrl: 'https://altinncdn.no/orgs/nav/nav.png',
   },
 };
@@ -104,8 +105,8 @@ export const ColorPlayground: StoryObj<typeof Avatar> = {
           }}
         >
           <h2>The avatar will look like this: </h2>
-          <Avatar name={name} companyName={useAsCompanyName ? name : ''} size="medium" />
-          <Avatar name={name} companyName={useAsCompanyName ? name : ''} size="small" />
+          <Avatar name={name} profile={useAsCompanyName ? 'organization' : 'person'} size="medium" />
+          <Avatar name={name} profile={useAsCompanyName ? 'organization' : 'person'} size="small" />
         </div>
       </div>
     );


### PR DESCRIPTION
Makes Avatar easier to use (API more transparent) by changing visual appearance based on companyName present or not, to instead accept a profile type.

Also fixes bug: `allOrganizationsSelected` not correctly calculated and remove uneccessary "private" label in menu (which was a part of refactor anyways)

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->