### PR TITLE
fix: Docker build times and caching of images locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ dev: ## Runs Docker compose in watch mode for development
 compose-down: ## Runs `docker compose down`
 	docker compose down
 
+pull: ## Pulls and stores images locally and builds project
+	docker compose pull && docker pull node:20-slim && docker compose build
+
 # ---------------------
 # - Helper functions  -
 # ---------------------

--- a/Readme.md
+++ b/Readme.md
@@ -43,5 +43,6 @@ CLIENT_SECRET=<secret_password_keep_this_private>
 Running Docker in watch mode:
 
 ```bash
+make pull (optional)
 make dev
 ```


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

Added command in Make-file to pull and store images locally in order to significantly reduce project startup time and bandwidth requirements.

Also updated readme file.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `pull` command in the Makefile for easier Docker image management and project building.
	- Updated the README to include the new optional `make pull` command for enhanced clarity in Docker setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->