### PR TITLE
fix: FOS toolbar no longer showing on top of global menu on mobile

### DIFF
--- a/packages/frontend/src/components/FosToolbar/fosToolbar.module.css
+++ b/packages/frontend/src/components/FosToolbar/fosToolbar.module.css
@@ -10,7 +10,7 @@
   outline-color: var(--button-color);
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   position: fixed;
-  z-index: 100;
+  z-index: 10;
   width: calc(100vw - 3rem);
   left: 0.5rem;
   bottom: 20px;


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->
![CleanShot 2024-09-24 at 14 11 43](https://github.com/user-attachments/assets/8d4fcf0f-7b85-46ce-8e28-7d6274158547)

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the `z-index` of the `FosToolbar` component for improved visibility and layering on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->