### PR TITLE
fix: merge to a single group of inbox items in for the viewtypes draft and sent

### DIFF
--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -137,6 +137,17 @@ export const Inbox = ({ viewType }: InboxProps) => {
       (d) => new Date(d.createdAt).getFullYear() === new Date().getFullYear(),
     );
 
+    const allAreDraftOrSent = itemsToDisplay.every((d) => ['drafts', 'sent'].includes(getViewType(d)));
+    if (!shouldShowSearchResults && allAreDraftOrSent) {
+      return [
+        {
+          label: t(`inbox.heading.title.${viewType}`, { count: itemsToDisplay.length }),
+          id: viewType,
+          items: itemsToDisplay,
+        },
+      ];
+    }
+
     return itemsToDisplay.reduce((acc, item, _, list) => {
       const createdAt = new Date(item.createdAt);
       const viewType = getViewType(item);
@@ -146,13 +157,9 @@ export const Inbox = ({ viewType }: InboxProps) => {
           ? format(createdAt, 'LLLL')
           : format(createdAt, 'yyyy');
 
-      let label = key;
-
-      if (shouldShowSearchResults) {
-        label = t(`inbox.heading.search_results.${key}`, { count: list.filter((i) => getViewType(i) === key).length });
-      } else if (['drafts', 'sent'].includes(viewType)) {
-        label = t(`inbox.heading.title.${viewType}`, { count: list.length });
-      }
+      const label = shouldShowSearchResults
+        ? t(`inbox.heading.search_results.${key}`, { count: list.filter((i) => getViewType(i) === key).length })
+        : key;
 
       const existingCategory = acc.find((c) => c.id === key);
 


### PR DESCRIPTION
Fixes https://github.com/digdir/dialogporten-frontend/issues/1150

![image](https://github.com/user-attachments/assets/ef959700-7d86-44cd-8a0f-3768aba6b667)



<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the Inbox component to prioritize displaying a summary for drafts and sent items when search results are not shown.

- **Bug Fixes**
	- Simplified logic for determining the display label, improving clarity and reducing redundancy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->