### PR TITLE
fix: use correct profile for avatar as sender in Inbox item detail page

### DIFF
--- a/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
@@ -79,7 +79,11 @@ export const InboxItemDetail = ({ dialog }: InboxItemDetailProps): JSX.Element =
       </header>
       <div className={styles.participants} data-id="dialog-sender-receiver">
         <div className={styles.sender}>
-          <Avatar name={sender?.name ?? ''} imageUrl={sender?.imageURL} />
+          <Avatar
+            name={sender?.name ?? ''}
+            imageUrl={sender?.imageURL}
+            profile={sender?.isCompany ? 'organization' : 'person'}
+          />
           <span className={styles.participantLabel}>{sender?.name}</span>
         </div>
         <span>{t('word.to')}</span>


### PR DESCRIPTION
Fixes https://github.com/digdir/dialogporten-frontend/issues/1156

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Avatar component to display sender type (individual or organization) based on the sender's profile.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->