### PR TITLE
fix: remove section header for activities and attachments if lists are empty

### DIFF
--- a/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
@@ -92,7 +92,9 @@ export const InboxItemDetail = ({ dialog }: InboxItemDetailProps): JSX.Element =
         <p className={styles.summary}>{summary}</p>
         <MainContentReference args={mainContentReference} dialogToken={dialogToken} />
         <section data-id="dialog-attachments" className={styles.dialogAttachments}>
-          <h2 className={styles.attachmentTitle}>{t('inbox.heading.attachments', { count: attachmentCount })}</h2>
+          {attachmentCount > 0 && (
+            <h2 className={styles.attachmentTitle}>{t('inbox.heading.attachments', { count: attachmentCount })}</h2>
+          )}
           <ul className={styles.attachments} data-id="dialog-attachments-list">
             {attachments.map((attachment) =>
               attachment.urls
@@ -137,7 +139,7 @@ export const InboxItemDetail = ({ dialog }: InboxItemDetailProps): JSX.Element =
         </section>
       )}
       <section data-id="dialog-activity-history" className={styles.activities}>
-        <h3 className={styles.activitiesTitle}>{t('word.activities')}</h3>
+        {activities.length > 0 && <h3 className={styles.activitiesTitle}>{t('word.activities')}</h3>}
         {activities.map((activity) => (
           <Activity key={activity.id} activity={activity} serviceOwner={sender} />
         ))}


### PR DESCRIPTION
Fixes #1164 

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user interface by conditionally displaying headers for attachments and activities only when relevant content exists.
  
- **Bug Fixes**
	- Resolved the issue of empty headers appearing when there are no attachments or activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->