### PR TITLE
fix: change format for date and display updated date instead of created date

### DIFF
--- a/packages/frontend/src/api/useDialogById.tsx
+++ b/packages/frontend/src/api/useDialogById.tsx
@@ -41,6 +41,7 @@ export interface DialogByIdDetails {
   dialogToken: string;
   mainContentReference?: MainContentReference;
   activities: DialogActivity[];
+  updatedAt: string;
   createdAt: string;
 }
 
@@ -175,6 +176,7 @@ export function mapDialogDtoToInboxItem(
       }))
       .reverse(),
     createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
   };
 }
 export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseDialogByIdOutput => {

--- a/packages/frontend/src/components/Header/SearchDropdown.tsx
+++ b/packages/frontend/src/components/Header/SearchDropdown.tsx
@@ -67,7 +67,9 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({ showDropdownMenu
                 isMinimalistic
               />
               <div className={cx(styles.rightContent)}>
-                <span className={styles.timeSince}>{autoFormatRelativeTime(new Date(item.date), formatDistance)}</span>
+                <span className={styles.timeSince}>
+                  {autoFormatRelativeTime(new Date(item.updatedAt), formatDistance)}
+                </span>
                 <Avatar
                   name={item.sender.name}
                   profile={item.sender.isCompany ? 'organization' : 'person'}

--- a/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
@@ -65,12 +65,15 @@ export const InboxItemDetail = ({ dialog }: InboxItemDetailProps): JSX.Element =
     attachments,
     mainContentReference,
     activities,
-    createdAt,
+    updatedAt,
   } = dialog;
   const attachmentCount = attachments.reduce(
     (count, { urls }) => count + urls.map((url) => url.consumerType === 'GUI').length,
     0,
   );
+
+  const clockPrefix = t('word.clock_prefix');
+  const formatString = clockPrefix ? `do MMMM yyyy '${clockPrefix}' HH.mm` : `do MMMM yyyy HH.mm`;
 
   return (
     <section className={styles.inboxItemDetail}>
@@ -88,7 +91,7 @@ export const InboxItemDetail = ({ dialog }: InboxItemDetailProps): JSX.Element =
         </div>
       </div>
       <div className={styles.sectionWithStatus} data-id="dialog-summary">
-        <p className={styles.createdLabel}>{format(createdAt, 'do MMMM yyyy HH:mm')}</p>
+        <p className={styles.updatedLabel}>{format(updatedAt, formatString)}</p>
         <p className={styles.summary}>{summary}</p>
         <MainContentReference args={mainContentReference} dialogToken={dialogToken} />
         <section data-id="dialog-attachments" className={styles.dialogAttachments}>

--- a/packages/frontend/src/components/InboxItem/inboxItemDetail.module.css
+++ b/packages/frontend/src/components/InboxItem/inboxItemDetail.module.css
@@ -92,7 +92,7 @@
   margin-top: 0;
 }
 
-.createdLabel {
+.updatedLabel {
   color: var(--text-neutral-subtle);
   font-size: 1rem;
   font-weight: 400;

--- a/packages/frontend/src/components/MetaDataFields/MetaDataFields.tsx
+++ b/packages/frontend/src/components/MetaDataFields/MetaDataFields.tsx
@@ -2,6 +2,7 @@ import { CheckmarkCircleFillIcon, EyeIcon, PaperclipIcon } from '@navikt/aksel-i
 import cx from 'classnames';
 import { t } from 'i18next';
 import type { InboxViewType } from '../../api/useDialogs.tsx';
+import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
 import { LoadingCircle } from '../LoadingCircle/LoadingCircle.tsx';
 import { MetaDataField } from './MetaDataField.tsx';
 import styles from './metaDataFields.module.css';
@@ -31,6 +32,7 @@ interface MetaDataFieldsProps {
 }
 
 export const MetaDataFields = ({ metaFields }: MetaDataFieldsProps) => {
+  const format = useFormat();
   const getIconByType = (type?: InboxItemMetaField['type']): JSX.Element | null => {
     switch (type) {
       case 'attachment':
@@ -86,12 +88,15 @@ export const MetaDataFields = ({ metaFields }: MetaDataFieldsProps) => {
                 <span className={styles.label}>{t('status.draft')}</span>
               </MetaDataField>
             );
-          case 'timestamp':
+          case 'timestamp': {
+            const clockPrefix = t('word.clock_prefix');
+            const formatString = clockPrefix ? `do MMMM yyyy '${clockPrefix}' HH.mm` : `do MMMM yyyy HH.mm`;
             return (
               <MetaDataField key={`metaField-${index}`}>
-                <span className={styles.label}>{metaField.label}</span>
+                <span className={styles.label}>{format(metaField.label, formatString)}</span>
               </MetaDataField>
             );
+          }
           default:
             return (
               <MetaDataField key={`metaField-${index}`}>

--- a/packages/frontend/src/components/SortOrderDropdown/SortOrderDropdown.tsx
+++ b/packages/frontend/src/components/SortOrderDropdown/SortOrderDropdown.tsx
@@ -9,7 +9,7 @@ import { MenuItem } from '../MenuBar';
 import { ProfileButton } from '../ProfileButton';
 import styles from './sortOrderDropdown.module.css';
 
-export type SortingOrder = 'created_desc' | 'created_asc';
+export type SortingOrder = 'updated_desc' | 'updated_asc';
 
 export type SortOrderDropdownRef = {
   openSortOrder: () => void;
@@ -28,12 +28,12 @@ interface SortOrderDropdownProps {
 
 const defaultSortOrderOptions = [
   {
-    id: 'created_desc' as SortingOrder,
-    label: t('sort_order.created_desc'),
+    id: 'updated_desc' as SortingOrder,
+    label: t('sort_order.updated_desc'),
   },
   {
-    id: 'created_asc' as SortingOrder,
-    label: t('sort_order.created_asc'),
+    id: 'updated_asc' as SortingOrder,
+    label: t('sort_order.updated_asc'),
   },
 ];
 

--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -123,8 +123,8 @@
   "sidebar.settings": "Settings",
   "sidebar.unread_messages.aria_count": "{count, plural, =0 {No saved messages} one {one saved message} other {# saved messages}}",
   "sort_order.choose.label": "Sort by",
-  "sort_order.created_asc": "Oldest first",
-  "sort_order.created_desc": "Newest first",
+  "sort_order.updated_asc": "Oldest first",
+  "sort_order.updated_desc": "Newest first",
   "status.completed": "Completed",
   "status.draft": "Draft",
   "status.in_progress": "In Progress",
@@ -148,5 +148,6 @@
   "word.seenBy": "Seen by",
   "word.status": "Status",
   "word.to": "to",
-  "word.you": "you"
+  "word.you": "you",
+  "word.clock_prefix": ""
 }

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -122,8 +122,8 @@
   "sidebar.settings": "Innstillinger",
   "sidebar.unread_messages.aria_count": "{count, plural, =0 {Ingen lagrede meldinger} one {en lagret melding} other {# lagrede meldinger}}",
   "sort_order.choose.label": "Sorter etter",
-  "sort_order.created_asc": "Eldste først",
-  "sort_order.created_desc": "Nyeste først",
+  "sort_order.updated_asc": "Eldste først",
+  "sort_order.updated_desc": "Nyeste først",
   "status.completed": "Avsluttet",
   "status.draft": "Utkast",
   "status.in_progress": "Under arbeid",
@@ -147,5 +147,6 @@
   "word.seenBy": "Sett av",
   "word.status": "Status",
   "word.to": "til",
-  "word.you": "deg"
+  "word.you": "deg",
+  "word.clock_prefix": "kl"
 }

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -49,8 +49,8 @@ export interface InboxItemInput {
   receiver: Participant;
   metaFields: InboxItemMetaField[];
   linkTo: string;
-  date: string;
   createdAt: string;
+  updatedAt: string;
   status: DialogStatus;
   isSeenByEndUser: boolean;
 }
@@ -62,10 +62,10 @@ interface DialogCategory {
 
 const sortDialogs = (dialogs: InboxItemInput[], sortOrder: SortingOrder): InboxItemInput[] => {
   return dialogs.sort((a, b) => {
-    if (sortOrder === 'created_desc') {
-      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    if (sortOrder === 'updated_desc') {
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
     }
-    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    return new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();
   });
 };
 
@@ -83,7 +83,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
   const { selectedItems, setSelectedItems, selectedItemCount, inSelectionMode } = useSelectedDialogs();
   const { openSnackbar } = useSnackbar();
   const [isSavingSearch, setIsSavingSearch] = useState<boolean>(false);
-  const [selectedSortOrder, setSelectedSortOrder] = useState<SortingOrder>('created_desc');
+  const [selectedSortOrder, setSelectedSortOrder] = useState<SortingOrder>('updated_desc');
 
   const { selectedParties } = useParties();
   const { searchString } = useSearchString();


### PR DESCRIPTION
Fixes https://github.com/digdir/dialogporten-frontend/issues/1166:

- `updated date` of dialog should be displayed, and sorting should by `updated date`, not `created date`.
- add `kl` to Norwegian locale

- refactors format to be used in jsx, not in mapping function (for more flexibility) - closes https://github.com/digdir/dialogporten-frontend/issues/784

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced the `updatedAt` property to track the last update timestamp for dialogs.
	- Updated sorting options to prioritize dialogs based on the `updatedAt` timestamp.

- **Bug Fixes**
	- Corrected date references in the UI to display the most recent update instead of the creation date.

- **Documentation**
	- Updated localization strings to reflect changes in sorting criteria from creation date to update date.

- **Style**
	- Renamed CSS classes to reflect the shift from creation to update context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->