### PR TITLE
feat: Summary field now has maximum two lines, overflow will be cut w…

### DIFF
--- a/packages/frontend/src/components/InboxItem/inboxItem.module.css
+++ b/packages/frontend/src/components/InboxItem/inboxItem.module.css
@@ -141,6 +141,7 @@
   text-overflow: ellipsis;
   margin-top: 1rem;
   margin-bottom: 1rem;
+  line-height: 1.35;
 }
 
 .minimalistic .summary {

--- a/packages/frontend/src/components/InboxItem/inboxItem.module.css
+++ b/packages/frontend/src/components/InboxItem/inboxItem.module.css
@@ -133,7 +133,10 @@
   font-size: 1rem;
   font-weight: 400;
   max-width: 600px;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
   margin-top: 1rem;

--- a/packages/frontend/src/components/MetaDataFields/metaDataFields.module.css
+++ b/packages/frontend/src/components/MetaDataFields/metaDataFields.module.css
@@ -3,8 +3,7 @@
   flex-direction: row;
   align-items: center;
   flex-wrap: wrap;
-  row-gap: 6px;
-  height: 1.5rem;
+  height: 100%;
 }
 
 .field {


### PR DESCRIPTION
Summary field now has maximum two lines, overflow will be cut with ellipsis as shown below:

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->
![CleanShot 2024-09-26 at 13 19 14](https://github.com/user-attachments/assets/39bb4f8f-db2b-4fb1-bd38-34780a35eda5)
![CleanShot 2024-09-26 at 13 19 05](https://github.com/user-attachments/assets/abcbbfaf-7521-44bd-8298-39fbe70141bb)

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced text display in inbox items with multi-line truncation, allowing for better readability by limiting visible lines to two and adding an ellipsis for overflow text.
	- Improved styling of metadata fields by allowing the container to take up the full height of its parent element, enhancing layout flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->