### PR TITLE
fix: add padding for 404 dialog not found fallback

### DIFF
--- a/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
@@ -11,7 +11,7 @@ import { GuiActions } from './GuiActions.tsx';
 import styles from './inboxItemDetail.module.css';
 
 interface InboxItemDetailProps {
-  dialog: DialogByIdDetails | undefined;
+  dialog: DialogByIdDetails | undefined | null;
 }
 
 /**
@@ -42,14 +42,17 @@ interface InboxItemDetailProps {
 export const InboxItemDetail = ({ dialog }: InboxItemDetailProps): JSX.Element => {
   const { t } = useTranslation();
   const format = useFormat();
+
   if (!dialog) {
     return (
-      <section className={styles.inboxItemDetail}>
-        <header className={styles.header} data-id="dialog-header">
-          <h1 className={styles.title}>{t('error.dialog.not_found')}</h1>
-        </header>
-        <p className={styles.summary}>{t('dialog.error_message')}</p>
-      </section>
+      <div className={styles.inboxItemDetailWrapper}>
+        <section className={styles.inboxItemDetail}>
+          <header className={styles.header} data-id="dialog-header">
+            <h1 className={styles.title}>{t('error.dialog.not_found')}</h1>
+          </header>
+          <p className={styles.summary}>{t('dialog.error_message')}</p>
+        </section>
+      </div>
     );
   }
 


### PR DESCRIPTION
When refactoring, I forgot to add padding for dialog not found scenario.


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility of the dialog property in the Inbox Item Detail component to accept null values.
  
- **Bug Fixes**
	- Improved rendering logic for the Inbox Item Detail component when the dialog is not provided, ensuring consistent styling and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->