### PR TITLE
feat: refactor context menu for button actions for saved searches

### DIFF
--- a/packages/frontend/src/components/Backdrop/useClickOutside.ts
+++ b/packages/frontend/src/components/Backdrop/useClickOutside.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react';
+
+export const useClickoutside = (callback: () => void) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    };
+
+    document.addEventListener('mouseup', handleClickOutside);
+    document.addEventListener('touchend', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mouseup', handleClickOutside);
+      document.removeEventListener('touchend', handleClickOutside);
+    };
+  }, [callback]);
+
+  return ref;
+};

--- a/packages/frontend/src/components/DropdownMenu/dropdownList.module.css
+++ b/packages/frontend/src/components/DropdownMenu/dropdownList.module.css
@@ -25,7 +25,7 @@
 }
 
 @media screen and (max-width: 1024px) {
-  .dropdownList {
+  .mobileDrawer {
     position: fixed;
     left: 0;
     top: 100px;

--- a/packages/frontend/src/components/DropdownMenu/dropdownList.tsx
+++ b/packages/frontend/src/components/DropdownMenu/dropdownList.tsx
@@ -6,9 +6,16 @@ interface DropdownListProps {
   isExpanded: boolean;
   variant?: 'short' | 'medium' | 'long';
   className?: string;
+  disableMobileDrawer?: boolean;
 }
 
-export const DropdownList = ({ children, className, variant = 'short', isExpanded }: DropdownListProps) => {
+export const DropdownList = ({
+  children,
+  className,
+  variant = 'short',
+  isExpanded,
+  disableMobileDrawer = false,
+}: DropdownListProps) => {
   if (!isExpanded) {
     return null;
   }
@@ -19,6 +26,7 @@ export const DropdownList = ({ children, className, variant = 'short', isExpande
         [styles.short]: variant === 'short',
         [styles.short]: variant === 'medium',
         [styles.long]: variant === 'long',
+        [styles.mobileDrawer]: !disableMobileDrawer,
       })}
     >
       {children}

--- a/packages/frontend/src/components/GlobalMenuBar/GlobalMenuBar.tsx
+++ b/packages/frontend/src/components/GlobalMenuBar/GlobalMenuBar.tsx
@@ -30,7 +30,9 @@ export const GlobalMenuBar: React.FC<GlobalMenuBarProps> = ({ name, profile, not
   const { t } = useTranslation();
 
   const toggleShowBackdrop = () => {
-    setShowBackDrop((prev) => !prev);
+    if (!showBackDrop) {
+      setShowBackDrop((prev) => !prev);
+    }
   };
 
   const handleClose = () => {

--- a/packages/frontend/src/components/GlobalMenuBar/NavigationDropdownMenu.tsx
+++ b/packages/frontend/src/components/GlobalMenuBar/NavigationDropdownMenu.tsx
@@ -27,8 +27,8 @@ export const NavigationDropdownMenu: React.FC<NavigationDropdownMenuProps> = ({
   const { t } = useTranslation();
 
   const handleClose = () => {
-    onClose?.();
     setShowSubMenu('none');
+    onClose?.();
   };
 
   if (showSubMenu !== 'none')

--- a/packages/frontend/src/pages/SavedSearches/EditSavedSearchDialog/EditSavedSearchDialog.tsx
+++ b/packages/frontend/src/pages/SavedSearches/EditSavedSearchDialog/EditSavedSearchDialog.tsx
@@ -59,8 +59,6 @@ export const EditSavedSearchDialog = forwardRef(
       editDialogRef.current?.close();
     };
 
-    if (typeof savedSearch?.id === 'undefined') return null;
-
     return (
       <Modal.Root>
         <Modal.Dialog onClose={onClose} ref={editDialogRef} onInteractOutside={onClose}>
@@ -96,14 +94,15 @@ export const EditSavedSearchDialog = forwardRef(
             <div className={styles.searchFormFooter}>
               <div className={styles.buttons}>
                 <Button onClick={handleSave}>{t('editSavedSearch.save_and_close')}</Button>
-                <Button variant="secondary" onClick={() => onDelete?.(savedSearch)}>
+                <Button variant="secondary" onClick={() => savedSearch && onDelete?.(savedSearch)}>
                   <TrashIcon className={styles.icon} aria-hidden="true" />
                   <span>{t('word.delete')}</span>
                 </Button>
               </div>
               <span className={styles.updateTime}>
                 {t('savedSearches.lastUpdated')}
-                {autoFormatRelativeTime(new Date(Number.parseInt(savedSearch?.updatedAt, 10)), formatDistance)}
+                {savedSearch?.updatedAt &&
+                  autoFormatRelativeTime(new Date(Number.parseInt(savedSearch.updatedAt, 10)), formatDistance)}
               </span>
             </div>
           </Modal.Footer>

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesActions/savedSearchesActions.module.css
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesActions/savedSearchesActions.module.css
@@ -1,50 +1,21 @@
-.renderButtons {
+.savedSearchesActions {
   display: flex;
   align-items: center;
 }
-
-.linkButton {
-  border: none;
-  background-color: #fff;
-  color: var(--black-50, rgba(0, 0, 0, 0.5));
-  cursor: pointer;
-}
-
-.linkButton:hover {
-  background-color: #fff;
-  color: var(--black-50, rgba(0, 0, 0, 0.5));
-}
-
 .icon {
-  width: 24px;
-  height: 24px;
+  min-width: 24px;
+  min-height: 24px;
+  max-width: 24px;
+  max-height: 24px;
+  color: #000;
 }
 
-.dropdownContent {
-  border-radius: 0;
-
-  li {
-    margin: 0;
-  }
-
-  button {
-    border-radius: 2px;
-    padding: 0;
-    height: auto;
-  }
+.leftInnerContent {
+  display: flex;
+  align-items: center;
+  column-gap: 0.5rem;
 }
 
-.dropdownEditSearch {
-  width: 100%;
-  display: grid;
-  grid-template-columns: min-content auto min-content;
-  align-items: start;
-  text-align: left;
-  gap: 6px;
-  padding: 6px;
-
-  & > svg,
-  & > span {
-    padding: 4px;
-  }
+.contextMenu {
+  right: 1rem;
 }


### PR DESCRIPTION
Includes fixing bugs:
- Global menu not dismissed on route change
- First time clicking on "edit name" doesn'† trigger open modal dialog

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a custom hook `useClickOutside` for improved interaction.
	- Added a new optional prop `disableMobileDrawer` to the `DropdownList` component.
	- Enhanced the `EditSavedSearchDialog` for better error handling and user experience.
	
- **Improvements**
	- Updated mobile dropdown menu styling for better usability on smaller screens.
	- Simplified the `SavedSearchesActions` component structure for easier interaction.
	
- **Bug Fixes**
	- Improved error handling when deleting saved searches and displaying last updated time.

- **Style Changes**
	- Renamed CSS classes and introduced new styles for better layout and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->