### PR TITLE
fix(frontend): avoid instrumenting application insights if bad key

### DIFF
--- a/packages/frontend/src/analytics.ts
+++ b/packages/frontend/src/analytics.ts
@@ -5,21 +5,32 @@ import { config } from './config';
 
 let applicationInsights: ApplicationInsights | null = null;
 
-if (config.applicationInsightsInstrumentationKey) {
-  const reactPlugin = new ReactPlugin();
-  try {
-    applicationInsights = new ApplicationInsights({
-      config: {
-        instrumentationKey: config.applicationInsightsInstrumentationKey,
-        extensions: [reactPlugin as ITelemetryPlugin],
-        enableAutoRouteTracking: true,
-      },
-    });
+// Function to validate the instrumentation key format
+function isValidInstrumentationKey(key: string): boolean {
+  // Basic format check: GUID format
+  const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return guidRegex.test(key);
+}
 
-    applicationInsights.loadAppInsights();
-  } catch (error) {
-    console.error('Failed to initialize Application Insights:', error);
-    applicationInsights = null;
+if (config.applicationInsightsInstrumentationKey) {
+  if (isValidInstrumentationKey(config.applicationInsightsInstrumentationKey)) {
+    const reactPlugin = new ReactPlugin();
+    try {
+      applicationInsights = new ApplicationInsights({
+        config: {
+          instrumentationKey: config.applicationInsightsInstrumentationKey,
+          extensions: [reactPlugin as ITelemetryPlugin],
+          enableAutoRouteTracking: true,
+        },
+      });
+      applicationInsights.loadAppInsights();
+      console.log('Application Insights initialized successfully');
+    } catch (error) {
+      console.error('Failed to initialize Application Insights:', error);
+      applicationInsights = null;
+    }
+  } else {
+    console.error('Invalid Application Insights instrumentation key format');
   }
 } else {
   console.warn('ApplicationInsightsInstrumentationKey is undefined. Tracking is disabled.');

--- a/packages/frontend/src/analytics.ts
+++ b/packages/frontend/src/analytics.ts
@@ -5,14 +5,12 @@ import { config } from './config';
 
 let applicationInsights: ApplicationInsights | null = null;
 
-// Application Insights expects a GUID format for the instrumentation key
-function isValidInstrumentationKey(key: string): boolean {
-  const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-  return guidRegex.test(key);
-}
-
 if (config.applicationInsightsInstrumentationKey) {
-  if (isValidInstrumentationKey(config.applicationInsightsInstrumentationKey)) {
+  if (!import.meta.env.PROD) {
+    console.warn(
+      'ApplicationInsightsInstrumentationKey is defined but not enabled in non-production builds. Tracking is disabled.',
+    );
+  } else {
     const reactPlugin = new ReactPlugin();
     try {
       applicationInsights = new ApplicationInsights({
@@ -28,8 +26,6 @@ if (config.applicationInsightsInstrumentationKey) {
       console.error('Failed to initialize Application Insights:', error);
       applicationInsights = null;
     }
-  } else {
-    console.error('Invalid Application Insights instrumentation key format');
   }
 } else {
   console.warn('ApplicationInsightsInstrumentationKey is undefined. Tracking is disabled.');

--- a/packages/frontend/src/analytics.ts
+++ b/packages/frontend/src/analytics.ts
@@ -5,27 +5,21 @@ import { config } from './config';
 
 let applicationInsights: ApplicationInsights | null = null;
 
-if (config.applicationInsightsInstrumentationKey) {
-  if (!import.meta.env.PROD) {
-    console.warn(
-      'ApplicationInsightsInstrumentationKey is defined but not enabled in non-production builds. Tracking is disabled.',
-    );
-  } else {
-    const reactPlugin = new ReactPlugin();
-    try {
-      applicationInsights = new ApplicationInsights({
-        config: {
-          instrumentationKey: config.applicationInsightsInstrumentationKey,
-          extensions: [reactPlugin as ITelemetryPlugin],
-          enableAutoRouteTracking: true,
-        },
-      });
-      applicationInsights.loadAppInsights();
-      console.log('Application Insights initialized successfully');
-    } catch (error) {
-      console.error('Failed to initialize Application Insights:', error);
-      applicationInsights = null;
-    }
+if (config.applicationInsightsInstrumentationKey && import.meta.env.PROD) {
+  const reactPlugin = new ReactPlugin();
+  try {
+    applicationInsights = new ApplicationInsights({
+      config: {
+        instrumentationKey: config.applicationInsightsInstrumentationKey,
+        extensions: [reactPlugin as ITelemetryPlugin],
+        enableAutoRouteTracking: true,
+      },
+    });
+    applicationInsights.loadAppInsights();
+    console.log('Application Insights initialized successfully');
+  } catch (error) {
+    console.error('Failed to initialize Application Insights:', error);
+    applicationInsights = null;
   }
 } else {
   console.warn('ApplicationInsightsInstrumentationKey is undefined. Tracking is disabled.');

--- a/packages/frontend/src/analytics.ts
+++ b/packages/frontend/src/analytics.ts
@@ -5,9 +5,8 @@ import { config } from './config';
 
 let applicationInsights: ApplicationInsights | null = null;
 
-// Function to validate the instrumentation key format
+// Application Insights expects a GUID format for the instrumentation key
 function isValidInstrumentationKey(key: string): boolean {
-  // Basic format check: GUID format
   const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   return guidRegex.test(key);
 }


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

When running this locally, the instrumentation key remains $APPLICATION_INSIGHTS_INSTRUMENTATION_KEY because we are using the build-stage of the Dockerfile and not the final nginx image. Using vite-environment variable to ensure we do not enable application insights if we are not using production builds

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced validation for the Application Insights instrumentation key to ensure it meets the expected format.
	- Added logging for success and error messages based on the validity of the instrumentation key.

- **Bug Fixes**
	- Enhanced error handling during the initialization process to provide clearer feedback on instrumentation key issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->