### PR TITLE
fix: ensure attachment are only counted if they have urls with consumer type GUI

### DIFF
--- a/packages/bff-types-generated/queries/dialog.fragment.graphql
+++ b/packages/bff-types-generated/queries/dialog.fragment.graphql
@@ -115,6 +115,7 @@ fragment AttachmentUrlFields on AttachmentUrl {
   id
   url
   consumerType
+  mediaType
 }
 
 fragment AttachmentFields on Attachment {

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -22,7 +22,7 @@
     "@azure/keyvault-keys": "^4.7.2",
     "@azure/monitor-opentelemetry": "1.7.0",
     "@digdir/dialogporten-node-logger": "workspace:*",
-    "@digdir/dialogporten-schema": "1.21.0-3031d8d",
+    "@digdir/dialogporten-schema": "1.22.0-3919343",
     "@fastify/cookie": "^9.3.1",
     "@fastify/cors": "^9.0.1",
     "@fastify/formbody": "^7.4.0",

--- a/packages/frontend/src/api/useDialogById.tsx
+++ b/packages/frontend/src/api/useDialogById.tsx
@@ -8,6 +8,7 @@ import type {
   PartyFieldsFragment,
   SystemLabel,
 } from 'bff-types-generated';
+import { AttachmentUrlConsumer } from 'bff-types-generated';
 import type { GuiActionButtonProps, InboxItemMetaField } from '../components';
 import { QUERY_KEYS } from '../constants/queryKeys.ts';
 import { i18n } from '../i18n/config.ts';
@@ -170,7 +171,9 @@ export function mapDialogDtoToInboxItem(
       isDeleteAction: guiAction.isDeleteDialogAction,
       disabled: !guiAction.isAuthorized,
     })),
-    attachments: item.attachments.filter((attachment) => attachment.urls.length > 0),
+    attachments: item.attachments.filter(
+      (a) => a.urls.filter((url) => url.consumerType === AttachmentUrlConsumer.Gui).length > 0,
+    ),
     mainContentReference: getMainContentReference(mainContentReference),
     dialogToken: item.dialogToken!,
     activities: item.activities

--- a/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItemDetail.tsx
@@ -1,6 +1,5 @@
 import { Link } from '@digdir/designsystemet-react';
 import { EyeIcon, FileIcon } from '@navikt/aksel-icons';
-import { AttachmentUrlConsumer } from 'bff-types-generated';
 import { useTranslation } from 'react-i18next';
 import { type DialogByIdDetails, getPropertyByCultureCode } from '../../api/useDialogById.tsx';
 import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
@@ -70,11 +69,8 @@ export const InboxItemDetail = ({ dialog }: InboxItemDetailProps): JSX.Element =
     activities,
     updatedAt,
   } = dialog;
-  const attachmentCount = attachments.reduce(
-    (count, { urls }) => count + urls.map((url) => url.consumerType === 'GUI').length,
-    0,
-  );
 
+  const attachmentCount = attachments.reduce((count, { urls }) => count + urls.length, 0);
   const clockPrefix = t('word.clock_prefix');
   const formatString = clockPrefix ? `do MMMM yyyy '${clockPrefix}' HH.mm` : `do MMMM yyyy HH.mm`;
 
@@ -111,21 +107,19 @@ export const InboxItemDetail = ({ dialog }: InboxItemDetailProps): JSX.Element =
             )}
             <ul className={styles.attachments} data-id="dialog-attachments-list">
               {attachments.map((attachment) =>
-                attachment.urls
-                  .filter((url) => url.consumerType === AttachmentUrlConsumer.Gui)
-                  .map((url) => (
-                    <li key={url.id} className={styles.attachmentItem}>
-                      <Link
-                        href={url.url}
-                        aria-label={t('inbox.attachment.link', {
-                          label: url.url,
-                        })}
-                      >
-                        <FileIcon className={styles.attachmentIcon} />
-                        {getPropertyByCultureCode(attachment.displayName) || url.url}
-                      </Link>
-                    </li>
-                  )),
+                attachment.urls.map((url) => (
+                  <li key={url.id} className={styles.attachmentItem}>
+                    <Link
+                      href={url.url}
+                      aria-label={t('inbox.attachment.link', {
+                        label: url.url,
+                      })}
+                    >
+                      <FileIcon className={styles.attachmentIcon} />
+                      {getPropertyByCultureCode(attachment.displayName) || url.url}
+                    </Link>
+                  </li>
+                )),
               )}
             </ul>
           </section>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: workspace:*
         version: link:../node-logger
       '@digdir/dialogporten-schema':
-        specifier: 1.21.0-3031d8d
-        version: 1.21.0-3031d8d
+        specifier: 1.22.0-3919343
+        version: 1.22.0-3919343
       '@fastify/cookie':
         specifier: ^9.3.1
         version: 9.3.1
@@ -5213,8 +5213,8 @@ packages:
     resolution: {integrity: sha512-JWCLhXxDlMYwatg7mLkptfEkeiv/EKSaUOXX4nUoV8HjqyxMnLaaZZe6NKqx2SH1GPKOeSL5bEcs2NAEoFlGXg==}
     dev: false
 
-  /@digdir/dialogporten-schema@1.21.0-3031d8d:
-    resolution: {integrity: sha512-6su49yojwmXGM8payIn1jYLW467pov2XttUkkxYFRCXJHopu//AxQvv/gyRQmabDpK6XV4gYnK2Mh8lK7655AA==}
+  /@digdir/dialogporten-schema@1.22.0-3919343:
+    resolution: {integrity: sha512-6ynL7++4ErkvLiTMboTryOUjuTy2XTubI9jsz5GsdAFxbWI5JnTJYTTuTBMHu0rvcpjXCiKNZJOGRDdjPRRllw==}
     engines: {node: '20'}
     dev: false
 


### PR DESCRIPTION
Started on https://github.com/digdir/dialogporten-frontend/issues/1228 (no longer valid) and did some refactoring. 
Felt like an isolated improvement, so pushing it as a PR on its own.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `mediaType` field in the attachment metadata, enhancing the information available for attachment URLs.
	- Added a new type `AttachmentUrlConsumer` to improve attachment handling.

- **Improvements**
	- Updated the logic for filtering attachments to include all URLs in the dialog details, improving the visibility of attachments in the inbox.
	- Simplified the attachment count logic to account for all URLs, ensuring accurate representation of attachments.

- **Dependency Updates**
	- Updated the version of the `@digdir/dialogporten-schema` dependency for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->