### PR TITLE
fix: SavedSearch action menu showing correctly on large screen sizes

### DIFF
--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesActions/savedSearchesActions.module.css
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesActions/savedSearchesActions.module.css
@@ -1,7 +1,9 @@
 .savedSearchesActions {
   display: flex;
   align-items: center;
+  position: relative;
 }
+
 .icon {
   min-width: 24px;
   min-height: 24px;
@@ -17,5 +19,7 @@
 }
 
 .contextMenu {
-  right: 1rem;
+  position: absolute;
+  top: 100%;
+  right: 0;
 }


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->
Now looks like:
![CleanShot 2024-10-16 at 11 05 04@2x](https://github.com/user-attachments/assets/8dac6588-5a4b-4003-8748-47d65f019c7a)

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated styles for the saved searches actions, enhancing the positioning of the context menu for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->