### PR TITLE
fix: fix date input field styles and popup not showing

### DIFF
--- a/packages/frontend/src/components/FilterBar/FilterButton/FilterButton.tsx
+++ b/packages/frontend/src/components/FilterBar/FilterButton/FilterButton.tsx
@@ -46,6 +46,7 @@ export const FilterButtonSection = ({ date, onListItemClick, id, onBack }: Filte
   const maxDate = format(new Date(end), 'yyyy-MM-dd');
   const [startDate, setStartDate] = useState<string>('');
   const [endDate, setEndDate] = useState<string>('');
+
   return (
     <section className={styles.filterDateContent}>
       <button type="button" className={styles.menuColumn} onClick={onBack}>
@@ -53,13 +54,15 @@ export const FilterButtonSection = ({ date, onListItemClick, id, onBack }: Filte
         <span className={styles.subMenuTitle}>{t('word.back')}</span>
       </button>
       <HorizontalLine />
-      <label htmlFor="fromDate">{t('filter_bar.from_date_label')}</label>
+      <label className={styles.dateInputLabel} htmlFor="fromDate">
+        {t('filter_bar.from_date_label')}
+      </label>
       <div className={styles.dateInputWrapper}>
         <input
           id="fromDate"
           key="fromDate"
           type="date"
-          value={startDate || minDate}
+          value={startDate ? startDate : ''}
           min={minDate}
           max={maxDate}
           className={styles.dateInputField}
@@ -76,7 +79,7 @@ export const FilterButtonSection = ({ date, onListItemClick, id, onBack }: Filte
         <input
           key="toDate"
           type="date"
-          value={endDate || maxDate}
+          value={endDate ? endDate : ''}
           min={minDate}
           className={styles.dateInputField}
           max={maxDate}

--- a/packages/frontend/src/components/FilterBar/FilterButton/filterButton.module.css
+++ b/packages/frontend/src/components/FilterBar/FilterButton/filterButton.module.css
@@ -34,6 +34,7 @@
 
 .checkMarkHolder {
   min-width: 1.5rem;
+
   svg {
     height: 1.5rem;
     width: auto;
@@ -83,31 +84,41 @@
   min-width: 300px;
   display: flex;
   flex-direction: column;
-  padding: 0.5rem;
+  padding: 0.5rem 0.5rem 1rem;
   row-gap: 1rem;
   margin-top: 0.5rem;
 }
 
+.dateInputLabel {
+  pointer-events: none;
+}
+
 .dateInputWrapper {
   display: flex;
+  justify-content: space-between;
   appearance: none;
   border-radius: 4px;
   border: 1px solid rgba(0, 0, 0, 0.5);
+  position: relative;
+}
+
+.dateInputWrapper:focus-within {
+  border: 1px solid var(--Action-Link);
 }
 
 .dateInputField {
   -webkit-appearance: none;
   -moz-appearance: textfield;
-  width: calc(100% - 1rem);
+  width: calc(100% - 2rem);
   appearance: none;
   padding: 8px;
   border: none;
+  outline: none;
 }
 
 .dateInputField::-webkit-inner-spin-button,
 .dateInputField::-webkit-calendar-picker-indicator {
-  display: none;
-  -webkit-appearance: none;
+  cursor: pointer;
 }
 
 .clearDateButton {
@@ -119,8 +130,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
   align-self: center;
+  padding-right: 16px;
 }
 
 .clearDateIcon {
@@ -131,7 +142,6 @@
   min-height: 16px;
   border-radius: 24px;
   background-color: var(--black-5, rgba(0, 0, 0, 0.05));
-  margin-right: 1rem;
   color: #000;
   padding: 2px;
 }


### PR DESCRIPTION
Fix styling for date input field, bring back default date popup. Adjust bottom spacing of the modal.

Closes [#1223](https://github.com/digdir/dialogporten-frontend/issues/1223)
## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved rendering of date input labels for better visibility.
	- Enhanced date input handling to ensure empty fields when no date is selected.

- **Style**
	- Updated CSS for better layout, responsiveness, and interaction of the `FilterButton` component.
	- Introduced new styles for date input labels and adjusted padding and alignment for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->