### PR TITLE
fix: allow refresh of access token from Graphql IDE

### DIFF
--- a/packages/bff/src/graphql/api.ts
+++ b/packages/bff/src/graphql/api.ts
@@ -1,7 +1,7 @@
 import { stitchSchemas } from '@graphql-tools/stitch';
 import type { AsyncExecutor } from '@graphql-tools/utils';
 import axios from 'axios';
-import type { FastifyPluginAsync } from 'fastify';
+import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import fp from 'fastify-plugin';
 import { print } from 'graphql';
 import { createHandler } from 'graphql-http/lib/use/fastify';
@@ -43,10 +43,20 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     },
   });
 
-  fastify.post('/api/graphql', { preHandler: fastify.verifyToken(false) }, async (request, reply) => {
-    await handler.call(fastify, request, reply);
-    return reply;
-  });
+  fastify.post(
+    '/api/graphql',
+    {
+      preHandler: (request: FastifyRequest, reply, callback) => {
+        /* Allow refresh to keep access token alive if request is from GraphQL IDE */
+        const shouldVerifyToken = request.headers.referer?.includes('/api/graphiql') ?? false;
+        return fastify.verifyToken(shouldVerifyToken)(request, reply, callback);
+      },
+    },
+    async (request, reply) => {
+      await handler.call(fastify, request, reply);
+      return reply;
+    },
+  );
 };
 
 export default fp(plugin, {


### PR DESCRIPTION
Closes https://github.com/digdir/dialogporten-frontend/issues/1258

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced token verification for the GraphQL endpoint, allowing requests from the GraphQL IDE to bypass token checks.

- **Bug Fixes**
	- Improved flexibility in handling token verification based on the request's referer header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->