### PR TITLE
fix: date range of custom date period in filters was based on wrong date

### DIFF
--- a/packages/frontend/src/pages/Inbox/filters.ts
+++ b/packages/frontend/src/pages/Inbox/filters.ts
@@ -133,7 +133,7 @@ export const getFilterBarSettings = (dialogs: InboxItemInput[], format: FormatFu
       unSelectedLabel: t('filter_bar.label.all_dates'),
       operation: 'equals',
       options: generateDateOptions(
-        dialogs.map((p) => new Date(p.createdAt)),
+        dialogs.map((p) => new Date(p.updatedAt)),
         format,
       ),
     },


### PR DESCRIPTION
They were based on created date of dialogs, but should be based on updated date.

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the 'created' filter to use the last updated date instead of the creation date, enhancing the relevance of the filter options for users.
  
- **Bug Fixes**
	- Ensured that the logic for grouping filters and applying AND/OR conditions remains consistent and functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->