### PR TITLE
chore: Reorganize graphql queries types in BFF

### DIFF
--- a/packages/bff/src/graphql/types/index.ts
+++ b/packages/bff/src/graphql/types/index.ts
@@ -2,3 +2,4 @@ export * from './profile.ts';
 export * from './query.ts';
 export * from './savedSearches.ts';
 export * from './organization.ts';
+export * from './mutation.ts';

--- a/packages/bff/src/graphql/types/mutation.ts
+++ b/packages/bff/src/graphql/types/mutation.ts
@@ -1,0 +1,75 @@
+import { extendType, intArg, nonNull, objectType, stringArg } from 'nexus';
+import { SavedSearchRepository } from '../../db.ts';
+import { SavedSearch, getOrCreateProfile } from '../../entities.ts';
+import { Response, SavedSearchInput, SavedSearches } from './index.ts';
+
+export const Mutation = extendType({
+  type: 'Mutation',
+  definition(t) {
+    t.field('deleteSavedSearch', {
+      type: Response,
+      args: {
+        id: nonNull(intArg()),
+      },
+      resolve: async (_, args) => {
+        const { id } = args;
+        try {
+          const result = await SavedSearchRepository!.delete({ id });
+          return { success: result?.affected && result?.affected > 0, message: 'Saved search deleted successfully' };
+        } catch (error) {
+          console.error('Failed to delete saved search:', error);
+          return { success: false, message: 'Failed to delete saved search' };
+        }
+      },
+    });
+  },
+});
+
+export const UpdateSavedSearch = extendType({
+  type: 'Mutation',
+  definition(t) {
+    t.field('updateSavedSearch', {
+      type: Response,
+      args: {
+        id: nonNull(intArg()),
+        name: stringArg(),
+      },
+      resolve: async (_, args) => {
+        const { id, name } = args;
+        try {
+          await SavedSearchRepository!.update(id, { name });
+          return { success: true, message: 'Saved search updated successfully' };
+        } catch (error) {
+          console.error('Failed to updated saved search:', error);
+          return { success: false, message: 'Failed to updated saved search' };
+        }
+      },
+    });
+  },
+});
+
+export const CreateSavedSearch = extendType({
+  type: 'Mutation',
+  definition(t) {
+    t.field('createSavedSearch', {
+      type: SavedSearches,
+      args: {
+        name: stringArg(),
+        data: SavedSearchInput,
+      },
+      resolve: async (_, { name, data }, ctx) => {
+        try {
+          const profile = await getOrCreateProfile(ctx.session.get('sub'), ctx.session.get('locale'));
+          const newSavedSearch = new SavedSearch();
+          newSavedSearch.name = name;
+          newSavedSearch.data = data;
+          newSavedSearch.profile = profile;
+          return await SavedSearchRepository!.save(newSavedSearch);
+        } catch (error) {
+          console.error('Failed to create saved search:', error);
+          return error;
+        }
+      },
+    });
+  },
+});

--- a/packages/bff/src/graphql/types/organization.ts
+++ b/packages/bff/src/graphql/types/organization.ts
@@ -34,7 +34,6 @@ interface TransformedOrganization {
 const organizationsRedisKey = 'transformedOrganizations';
 
 async function fetchOrganizations() {
-  const { default: logger } = await import('@digdir/dialogporten-node-logger');
   try {
     const response = await fetch('https://altinncdn.no/orgs/altinn-orgs.json');
     if (!response.ok) {
@@ -97,19 +96,19 @@ export const OrganizationNames = objectType({
   definition(t) {
     t.string('en', {
       description: 'Localized english name of the organization',
-      resolve: (organization, args, ctx, info) => {
+      resolve: (organization) => {
         return organization.en;
       },
     });
     t.string('nb', {
       description: 'Localized norwegian name of the organization',
-      resolve: (organization, args, ctx, info) => {
+      resolve: (organization) => {
         return organization.nb;
       },
     });
     t.string('nn', {
       description: 'Localized new norwegian name of the organization',
-      resolve: (organization, args, ctx, info) => {
+      resolve: (organization) => {
         return organization.nn;
       },
     });
@@ -121,38 +120,38 @@ export const Organization = objectType({
   definition(t) {
     t.string('id', {
       description: 'Organization id',
-      resolve: (organization, args, ctx, info) => {
+      resolve: (organization) => {
         return organization.id;
       },
     });
     t.field('name', {
       type: 'OrganizationNames',
       description: 'Localized name of the organization',
-      resolve: (organization, args, ctx, info) => {
+      resolve: (organization) => {
         return organization.name;
       },
     });
     t.string('logo', {
       description: 'URL to the organization logo',
-      resolve: (organization, args, ctx, info) => {
+      resolve: (organization) => {
         return organization.logo;
       },
     });
     t.string('orgnr', {
       description: 'Organization number',
-      resolve: (organization, args, ctx, info) => {
+      resolve: (organization) => {
         return organization.orgnr;
       },
     });
     t.string('homepage', {
       description: 'Homepage URL of the organization',
-      resolve: (organization, args, ctx, info) => {
+      resolve: (organization) => {
         return organization.homepage;
       },
     });
     t.list.string('environments', {
       description: 'Environments the organization operates in',
-      resolve: (organization, args, ctx, info) => {
+      resolve: (organization) => {
         return organization.environments;
       },
     });
@@ -165,7 +164,7 @@ export const OrganizationQuery = extendType({
     t.list.field('organizations', {
       type: 'Organization',
       description: 'List of organizations',
-      resolve: async (_, args, ctx) => {
+      resolve: async () => {
         return await getOrganizationsFromRedis();
       },
     });

--- a/packages/bff/src/graphql/types/profile.ts
+++ b/packages/bff/src/graphql/types/profile.ts
@@ -5,13 +5,13 @@ export const Profile = objectType({
   definition(t) {
     t.string('language', {
       description: 'Preferred language for the profile',
-      resolve: (profile, args, ctx, info) => {
+      resolve: (profile) => {
         return profile.language;
       },
     });
     t.string('updatedAt', {
       description: 'Last updated',
-      resolve: (profile, args, ctx, info) => {
+      resolve: (profile) => {
         return profile.updatedAt;
       },
     });

--- a/packages/bff/src/graphql/types/query.ts
+++ b/packages/bff/src/graphql/types/query.ts
@@ -8,7 +8,7 @@ export const Query = objectType({
   definition(t) {
     t.field('profile', {
       type: 'Profile',
-      resolve: async (source, args, ctx, info) => {
+      resolve: async (_source, _args, ctx) => {
         const sub = ctx.session.get('sub');
         const locale = ctx.session.get('locale');
         const profile = await getOrCreateProfile(sub, locale);
@@ -22,7 +22,7 @@ export const Query = objectType({
 
     t.field('organizations', {
       type: list('Organization'),
-      resolve: async (source, args, ctx, info) => {
+      resolve: async () => {
         try {
           return await getOrganizationsFromRedis();
         } catch (error) {
@@ -34,7 +34,7 @@ export const Query = objectType({
 
     t.field('savedSearches', {
       type: list('SavedSearches'),
-      resolve: async (source, args, ctx, info) => {
+      resolve: async (_source, _args, ctx) => {
         const sub = ctx.session.get('sub');
         if (SavedSearchRepository) {
           return await SavedSearchRepository.find({

--- a/packages/bff/src/graphql/types/savedSearches.ts
+++ b/packages/bff/src/graphql/types/savedSearches.ts
@@ -1,83 +1,10 @@
-import { arg, extendType, inputObjectType, intArg, list, nonNull, objectType, stringArg } from 'nexus';
-import { SavedSearchRepository } from '../../db.ts';
-import { SavedSearch, getOrCreateProfile } from '../../entities.ts';
-
-export const Mutation = extendType({
-  type: 'Mutation',
-  definition(t) {
-    t.field('deleteSavedSearch', {
-      type: Response,
-      args: {
-        id: nonNull(intArg()),
-      },
-      resolve: async (_, args, ctx) => {
-        const { id } = args;
-        try {
-          const result = await SavedSearchRepository!.delete({ id });
-          return { success: result?.affected && result?.affected > 0, message: 'Saved search deleted successfully' };
-        } catch (error) {
-          console.error('Failed to delete saved search:', error);
-          return { success: false, message: 'Failed to delete saved search' };
-        }
-      },
-    });
-  },
-});
+import { inputObjectType, list, objectType } from 'nexus';
 
 export const Response = objectType({
   name: 'Response',
   definition(t) {
     t.nonNull.boolean('success');
     t.string('message');
-  },
-});
-
-export const UpdateSavedSearch = extendType({
-  type: 'Mutation',
-  definition(t) {
-    t.field('updateSavedSearch', {
-      type: Response,
-      args: {
-        id: nonNull(intArg()),
-        name: stringArg(),
-      },
-      resolve: async (_, args, ctx) => {
-        const { id, name } = args;
-        try {
-          await SavedSearchRepository!.update(id, { name });
-          return { success: true, message: 'Saved search updated successfully' };
-        } catch (error) {
-          console.error('Failed to updated saved search:', error);
-          return { success: false, message: 'Failed to updated saved search' };
-        }
-      },
-    });
-  },
-});
-
-export const CreateSavedSearch = extendType({
-  type: 'Mutation',
-  definition(t) {
-    t.field('createSavedSearch', {
-      type: SavedSearches,
-      args: {
-        name: stringArg(),
-        data: SavedSearchInput,
-      },
-      resolve: async (_, { name, data }, ctx) => {
-        try {
-          const profile = await getOrCreateProfile(ctx.session.get('sub'), ctx.session.get('locale'));
-          const newSavedSearch = new SavedSearch();
-          newSavedSearch.name = name;
-          newSavedSearch.data = data;
-          newSavedSearch.profile = profile;
-          return await SavedSearchRepository!.save(newSavedSearch);
-        } catch (error) {
-          console.error('Failed to create saved search:', error);
-          return error;
-        }
-      },
-    });
   },
 });
 
@@ -108,34 +35,19 @@ export const SavedSearches = objectType({
   definition(t) {
     t.int('id', {
       description: 'id of savedSearch',
-      resolve: (source, args, ctx, info) => {
-        return source.id;
-      },
     });
     t.string('name', {
       description: 'Name of saved search',
-      resolve: (source, args, ctx, info) => {
-        return source.name;
-      },
     });
     t.field('data', {
       type: 'SavedSearchData',
       description: 'Data of saved search, contains searchString and filters',
-      resolve: (source, args, ctx, info) => {
-        return source.data;
-      },
     });
     t.string('createdAt', {
       description: 'createdAt',
-      resolve: (source, args, ctx, info) => {
-        return source.createdAt;
-      },
     });
     t.string('updatedAt', {
       description: 'updatedAt',
-      resolve: (source, args, ctx, info) => {
-        return source.updatedAt;
-      },
     });
   },
 });
@@ -145,28 +57,16 @@ export const SavedSearchData = objectType({
   definition(t) {
     t.string('searchString', {
       description: 'searchString of savedSearch',
-      resolve: (source, args, ctx, info) => {
-        return source.searchString;
-      },
     });
     t.string('fromView', {
       description: 'fromView of savedSearch',
-      resolve: (source, args, ctx, info) => {
-        return source.fromView;
-      },
     });
     t.list.string('urn', {
       description: 'urns of savedSearch',
-      resolve: (source, args, ctx, info) => {
-        return source.urn;
-      },
     });
     t.field('filters', {
       type: list('SearchDataValueFilter'),
       description: 'filters for SearchDataFilter',
-      resolve: (source, args, ctx, info) => {
-        return source.filters;
-      },
     });
   },
 });
@@ -176,15 +76,9 @@ export const SearchDataValueFilter = objectType({
   definition(t) {
     t.string('id', {
       description: 'id',
-      resolve: (source, args, ctx, info) => {
-        return source.id;
-      },
     });
     t.string('value', {
       description: 'value',
-      resolve: (source, args, ctx, info) => {
-        return source.value;
-      },
     });
   },
 });


### PR DESCRIPTION
Reorganize graphql queries types in bff and move mutations types generators to its own file 

Closes #1255
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `Response` object type to provide feedback on mutation success.

- **Improvements**
	- Simplified resolver function signatures across various object types for better clarity and maintainability.
	- Enhanced module interface by consolidating exports from the mutation module.

- **Bug Fixes**
	- Removed unused parameters from resolver functions to streamline operations.
  
- **Chores**
	- Removed mutation fields from the `Mutation` type to reduce complexity in operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->