### PR TITLE
chore: disable access to grqphiql by default

### DIFF
--- a/.azure/applications/bff/main.bicep
+++ b/.azure/applications/bff/main.bicep
@@ -16,6 +16,13 @@ param oicdUrl string
 param minReplicas int
 param maxReplicas int
 
+@description('Controls whether GraphiQL interface is enabled. Should be disabled in production.')
+@allowed([
+  'false'
+  'true'
+])
+param graphiQLEnabled string = 'true'
+
 @minLength(3)
 @secure()
 param containerAppEnvironmentName string
@@ -150,6 +157,10 @@ var containerAppEnvVars = [
   {
     name: 'NODE_ENV'
     value: 'production'
+  }
+  {
+    name: 'ENABLE_GRAPHIQL'
+    value: graphiQLEnabled
   }
 ]
 

--- a/.azure/applications/bff/prod.bicepparam
+++ b/.azure/applications/bff/prod.bicepparam
@@ -8,6 +8,7 @@ param dialogportenURL = 'https://altinn-prod-api.azure-api.net/dialogporten/grap
 param oicdUrl = 'idporten.no'
 param minReplicas = 2
 param maxReplicas = 3
+param graphiQLEnabled = 'false'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('ENVIRONMENT_KEY_VAULT_NAME')

--- a/compose.yml
+++ b/compose.yml
@@ -108,6 +108,7 @@ services:
       HOSTNAME: http://app.localhost
       CLIENT_ID: ${CLIENT_ID}
       CLIENT_SECRET: ${CLIENT_SECRET}
+      ENABLE_GRAPHIQL: true
       OIDC_URL: test.idporten.no
       SESSION_SECRET: IDPortenSessionSecret2023MoreLettersBlaBla
       TYPEORM_SYNCHRONIZE_ENABLED: true

--- a/packages/bff/src/config.ts
+++ b/packages/bff/src/config.ts
@@ -21,6 +21,7 @@ const envVariables = z.object({
   MIGRATION_RUN: z.coerce.boolean().default(false),
   DIALOGPORTEN_URL: z.string().default('https://altinn-dev-api.azure-api.net/dialogporten/graphql'),
   CONTAINER_APP_REPLICA_NAME: z.string().default(''),
+  ENABLE_GRAPHIQL: z.coerce.boolean().default(true),
 });
 
 const env = envVariables.parse(process.env);
@@ -51,6 +52,7 @@ const config = {
   typeormSynchronizeEnabled: env.TYPEORM_SYNCHRONIZE_ENABLED,
   migrationRun: env.MIGRATION_RUN,
   dialogportenURL: env.DIALOGPORTEN_URL,
+  enableGraphiql: env.ENABLE_GRAPHIQL,
 };
 
 export default config;

--- a/packages/bff/src/server.ts
+++ b/packages/bff/src/server.ts
@@ -39,7 +39,7 @@ const startServer = async (): Promise<void> => {
   server.register(cookie);
 
   // Session setup
-  const { secret, enableHttps, cookieMaxAge } = config;
+  const { secret, enableHttps, cookieMaxAge, enableGraphiql } = config;
   const cookieSessionConfig: FastifySessionOptions = {
     secret,
     cookie: {
@@ -73,11 +73,12 @@ const startServer = async (): Promise<void> => {
   server.register(userApi);
   server.register(graphqlApi);
   server.register(graphqlStream);
-
-  server.register(fastifyGraphiql, {
-    url: '/api/graphiql',
-    graphqlURL: '/api/graphql',
-  });
+  if (enableGraphiql) {
+    server.register(fastifyGraphiql, {
+      url: '/api/graphiql',
+      graphqlURL: '/api/graphql',
+    });
+  }
 
   server.listen({ port, host }, (error, address) => {
     if (error) {


### PR DESCRIPTION
Closes: [#1016](https://github.com/digdir/dialogporten-frontend/issues/1016)
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable, `ENABLE_GRAPHIQL`, allowing users to enable or disable the GraphiQL interface.
	- Conditional registration of the GraphiQL plugin based on the `enableGraphiql` configuration.
	- Enhanced Docker Compose configuration for the `bff` and `bff-migration` services with new environment variables for improved management.
	- Added a new parameter `graphiQLEnabled` to configuration files for flexible GraphiQL functionality control.

- **Bug Fixes**
	- Removed commented-out lines related to `ENABLE_GRAPHIQL`, clarifying its implementation status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->