### PR TITLE
fix: history saving when navigate through parties

### DIFF
--- a/packages/frontend/tests/stories/loginPartyContext.spec.ts
+++ b/packages/frontend/tests/stories/loginPartyContext.spec.ts
@@ -75,7 +75,7 @@ test.describe('LoginPartyContext', () => {
     await expect(page.getByRole('button', { name: 'Test Testesen' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'This is a message 1 for Firma AS' })).not.toBeVisible();
 
-    await expect(page.getByTestId('pageLayout-background')).not.toHaveClass('isCompany');
+    await expect(page.getByTestId('pageLayout-background')).not.toHaveClass(/.*isCompany.*/);
 
     await page.getByRole('button', { name: 'Test Testesen' }).click();
     await page.locator('li').filter({ hasText: 'Firma AS' }).click();
@@ -108,5 +108,23 @@ test.describe('LoginPartyContext', () => {
     await page.reload();
     await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Melding om bortkjøring av snø' })).not.toBeVisible();
+  });
+
+  test('Go-back button updates state and shows correct data and color theme', async ({ page }: { page: Page }) => {
+    await expect(page.getByRole('button', { name: 'Test Testesen' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Innkalling til sesjon' })).not.toBeVisible();
+
+    await page.getByRole('button', { name: 'Test Testesen' }).click();
+    await page.getByText('Alle virksomheter').click();
+    await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).not.toBeVisible();
+    await expect(page.getByRole('link', { name: 'Innkalling til sesjon' })).toBeVisible();
+    await expect(page.getByTestId('pageLayout-background')).toHaveClass(/.*isCompany.*/);
+
+    await page.goBack();
+    await expect(page.getByRole('button', { name: 'Test Testesen' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Innkalling til sesjon' })).not.toBeVisible();
+    await expect(page.getByTestId('pageLayout-background')).not.toHaveClass(/.*isCompany.*/);
   });
 });


### PR DESCRIPTION
Closes: [#1346 ](https://github.com/digdir/dialogporten-frontend/issues/1346)
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced party selection functionality with improved clarity and maintainability.
	- Added support for accessing the current location in the `useParties` hook.

- **Tests**
	- Introduced a new test case for verifying the "Go-back" button functionality and its impact on UI elements.
	- Updated assertion logic for class checking in existing tests for better flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->