### PR TITLE
fix: Prevent filters from disappearing if no messages found, add tran…

### DIFF
--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -61,6 +61,7 @@
   "inbox.heading.attachments": "{count, plural, =0 {No attachments} one {# attachment} other {# attachments}}",
   "inbox.heading.choose_all": "Select All",
   "inbox.heading.no_results": "No messages",
+  "inbox.heading.no_results.filtered": "No messages found with the selected filters",
   "inbox.heading.no_results.inbox": "No messages in inbox",
   "inbox.heading.no_results.drafts": "No messages in drafts",
   "inbox.heading.no_results.sent": "No sent messages",

--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -61,7 +61,7 @@
   "inbox.heading.attachments": "{count, plural, =0 {No attachments} one {# attachment} other {# attachments}}",
   "inbox.heading.choose_all": "Select All",
   "inbox.heading.no_results": "No messages",
-  "inbox.heading.no_results.filtered": "No messages found with the selected filters",
+  "inbox.heading.no_results.filtered": "No messages found with selected filters",
   "inbox.heading.no_results.inbox": "No messages in inbox",
   "inbox.heading.no_results.drafts": "No messages in drafts",
   "inbox.heading.no_results.sent": "No sent messages",

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -61,6 +61,7 @@
   "inbox.heading.attachments": "{count, plural, =0 {Ingen vedlegg} one {# vedlegg} other {# vedlegg}}",
   "inbox.heading.choose_all": "Velg alle",
   "inbox.heading.no_results": "Ingen meldinger",
+  "inbox.heading.no_results.filtered": "Ingen meldinger funnet med valgte filtrene",
   "inbox.heading.no_results.inbox": "Ingen meldinger i innboks",
   "inbox.heading.no_results.drafts": "Ingen meldinger i utkast",
   "inbox.heading.no_results.sent": "Ingen sendte meldinger",

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -246,6 +246,29 @@ export const Inbox = ({ viewType }: InboxProps) => {
     );
   }
 
+  if (itemsToDisplay.length === 0 && activeFilters.length > 0 && dialogsIsSuccess) {
+    return (
+      <main>
+        <section className={styles.filtersArea}>
+          <div className={styles.gridContainer}>
+            <div className={styles.filterSaveContainer}>
+              <PartyDropdown counterContext={viewType} />
+              <FilterBar
+                ref={filterBarRef}
+                settings={filterBarSettings}
+                onFilterChange={setActiveFilters}
+                initialFilters={initialFilters}
+                addFilterBtnClassNames={styles.hideForSmallScreens}
+                resultsCount={itemsToDisplay.length}
+              />
+            </div>
+          </div>
+        </section>
+        <InboxItemsHeader title={t(`inbox.heading.no_results.filtered`)} />
+      </main>
+    );
+  }
+
   if (itemsToDisplay.length === 0 && dialogsIsSuccess) {
     return (
       <main>

--- a/packages/frontend/tests/stories/filter.spec.ts
+++ b/packages/frontend/tests/stories/filter.spec.ts
@@ -26,4 +26,36 @@ test.describe('Testing filter bar', () => {
     await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Søknad om personlig bilskilt' })).toBeVisible();
   });
+
+  test('No results displaying correct message and filters', async ({ page }) => {
+    await page.goto(appURL);
+    await expect(page.getByText('Skatten din for 2022')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Legg til filter' }).click();
+    await page.getByText('Avsender').click();
+    await page.getByLabel('Fra Oslo kommune').check();
+    await page.mouse.click(200, 0, { button: 'left' });
+
+    await page.getByRole('button', { name: 'Legg til filter' }).click();
+    await page.getByText('Status').click();
+    await page.getByLabel('Nye').check();
+    await page.mouse.click(200, 0, { button: 'left' });
+
+    const avsenderFilterRemoveBtn = page
+      .getByRole('button', { name: 'Fra Oslo kommune' })
+      .locator('..')
+      .locator('button')
+      .nth(1);
+    const statusFilterRemoveBtn = page.getByRole('button', { name: 'Nye' }).locator('..').locator('button').nth(1);
+
+    await expect(page.getByText('Ingen meldinger funnet med valgte filtrene')).toBeVisible();
+    await expect(page.getByText('Skatten din for 2022')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Fra Oslo kommune' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Nye' })).toBeVisible();
+
+    await avsenderFilterRemoveBtn.click();
+    await statusFilterRemoveBtn.click();
+
+    await expect(page.getByText('Skatten din for 2022')).toBeVisible();
+  });
 });


### PR DESCRIPTION
Prevent filters from disappearing if no messages found, add translation for this case.

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #1315

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added localized messages for English and Norwegian to inform users when no messages are found after applying filters in the inbox.
	- Enhanced the `Inbox` component to display a message and filter options when no items match the active filters.

- **Bug Fixes**
	- Improved conditional rendering logic in the `Inbox` component for better feedback when filters yield no results.

- **Tests**
	- Introduced a new test case to validate the user experience when no results match the applied filters, ensuring appropriate messages and filter states are displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->