### PR TITLE
fix: refactor in-message back button logic, preserve party context

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -18,8 +18,8 @@ function App() {
           <Route path={AppRoutes.sent} element={<Inbox key="sent" viewType={'sent'} />} />
           <Route path={AppRoutes.archive} element={<Inbox key="archive" viewType={'archive'} />} />
           <Route path={AppRoutes.bin} element={<Inbox key="bin" viewType={'bin'} />} />
-          <Route path={AppRoutes.savedSearches} element={<SavedSearchesPage />} />
           <Route path={AppRoutes.inboxItem} element={<InboxItemPage />} />
+          <Route path={AppRoutes.savedSearches} element={<SavedSearchesPage />} />
           <Route path="*" element={<Navigate to="/" />} />
         </Route>
         <Route path="/loggedout" element={<Logout />} />

--- a/packages/frontend/src/components/BackButton/BackButton.tsx
+++ b/packages/frontend/src/components/BackButton/BackButton.tsx
@@ -5,14 +5,10 @@ import { Link } from 'react-router-dom';
 import { Button } from '@digdir/designsystemet-react';
 import styles from './backButton.module.css';
 
-interface BackButtonProps {
-  pathTo: string;
-}
-
-export function BackButton({ pathTo }: BackButtonProps) {
+export function BackButton({ path }: { path: string }) {
   const { t } = useTranslation();
   return (
-    <Link to={pathTo} rel="noreferrer" className={styles.backLink}>
+    <Link to={path} rel="noreferrer" className={styles.backLink}>
       <Button color="neutral" variant="tertiary" className={styles.backButton}>
         <ArrowLeftIcon className={styles.backIcon} />
         {t('word.back')}

--- a/packages/frontend/src/components/InboxItem/InboxItem.tsx
+++ b/packages/frontend/src/components/InboxItem/InboxItem.tsx
@@ -6,8 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { Participant } from '../../api/useDialogById.tsx';
 import type { InboxViewType } from '../../api/useDialogs.tsx';
-import { FeatureFlagKeys } from '../../featureFlags';
-import { useFeatureFlag } from '../../featureFlags';
+import { FeatureFlagKeys, useFeatureFlag } from '../../featureFlags';
 import type { InboxItemMetaField } from '../MetaDataFields';
 import { MetaDataFields } from '../MetaDataFields';
 import { useSelectedDialogs } from '../PageLayout';
@@ -20,11 +19,11 @@ interface InboxItemProps {
   summary: string;
   sender: Participant;
   receiver: Participant;
+  linkTo: string;
   isChecked?: boolean;
   onCheckedChange?: (value: boolean) => void;
   metaFields?: InboxItemMetaField[];
   isUnread?: boolean;
-  linkTo?: string;
   isMinimalistic?: boolean;
   onClose?: () => void;
   isSeenByEndUser?: boolean;
@@ -40,7 +39,7 @@ export const OptionalLinkContent = ({
 }) => {
   if (linkTo) {
     return (
-      <Link to={linkTo} className={styles.link}>
+      <Link to={linkTo} state={{ fromView: location.pathname }} className={styles.link}>
         {children}
       </Link>
     );
@@ -89,11 +88,11 @@ export const InboxItem = ({
   metaFields = [],
   onCheckedChange,
   checkboxValue,
-  linkTo,
   onClose,
   isUnread = false,
   isMinimalistic = false,
   isChecked = false,
+  linkTo,
   viewType,
 }: InboxItemProps): JSX.Element => {
   const { inSelectionMode } = useSelectedDialogs();

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -340,8 +340,8 @@ export const Inbox = ({ viewType }: InboxProps) => {
                   isChecked={selectedItems[item.id]}
                   onCheckedChange={(checked) => handleCheckedChange(item.id, checked)}
                   metaFields={item.metaFields}
-                  linkTo={`/inbox/${item.id}/${location.search}`}
                   viewType={viewType}
+                  linkTo={`/inbox/${item.id}/${location.search}`}
                 />
               ))}
             </InboxItems>

--- a/packages/frontend/src/pages/InboxItemPage/InboxItemPage.tsx
+++ b/packages/frontend/src/pages/InboxItemPage/InboxItemPage.tsx
@@ -2,7 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { SystemLabel } from 'bff-types-generated';
 import i18n from 'i18next';
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { updateSystemLabel } from '../../api/queries.ts';
 import { useDialogById } from '../../api/useDialogById.tsx';
 import { useDialogByIdSubscription } from '../../api/useDialogByIdSubscription.ts';
@@ -17,6 +17,7 @@ import styles from './inboxItemPage.module.css';
 export const InboxItemPage = () => {
   const { id } = useParams();
   const { parties } = useParties();
+  const location = useLocation();
   const { dialog, isLoading } = useDialogById(parties, id);
   const [archiveLoading, setArchiveLoading] = useState<boolean>(false);
   const [deleteLoading, setDeleteLoading] = useState<boolean>(false);
@@ -104,11 +105,13 @@ export const InboxItemPage = () => {
     return <InboxItemPageSkeleton />;
   }
 
+  const previousPath = (location?.state?.fromView ?? '/') + location.search;
+
   return (
     <main className={styles.itemInboxPage}>
       <section className={styles.itemInboxPageContent}>
         <nav className={styles.itemInboxNav}>
-          <BackButton pathTo="/inbox/" />
+          <BackButton path={previousPath} />
         </nav>
         <InboxItemDetail dialog={dialog} />
       </section>

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesItem/SavedSearchesItem.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesItem/SavedSearchesItem.tsx
@@ -1,5 +1,6 @@
 import type { SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import { HorizontalLine } from '../../../components';
 import { PlusIcon } from '../../../components/Icons/PlusIcon/PlusIcon.tsx';
 import SearchFilterTag from '../SearchFilterTag/SearchFilterTag.tsx';
@@ -30,9 +31,9 @@ export const SavedSearchesItem = ({ savedSearch, actionPanel, isLast }: SavedSea
       <>
         <div className={styles.savedSearchItem} key={savedSearch.id}>
           <div className={styles.searchDetails}>
-            <a href={`${fromView}?${queryParams.toString()}`} className={styles.goToSavedSearchLink}>
+            <Link to={`${fromView}?${queryParams.toString()}`} className={styles.goToSavedSearchLink}>
               {savedSearch.name}
-            </a>
+            </Link>
           </div>
           <div>{actionPanel}</div>
         </div>

--- a/packages/frontend/tests/stories/messageNavigation.spec.ts
+++ b/packages/frontend/tests/stories/messageNavigation.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+import { appURL } from '../';
+
+test.describe('Message navigation', () => {
+  const pageWithMockOrganizations = `${appURL}&playwrightId=login-party-context`;
+
+  test('Back button navigates correctly and saves party', async ({ page }) => {
+    await page.goto(pageWithMockOrganizations);
+
+    await expect(page.getByRole('button', { name: 'Test Testesen' })).toBeVisible();
+    await expect(page.getByTestId('pageLayout-background')).not.toHaveClass(/.*isCompany.*/);
+    await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).toBeVisible();
+    await page.getByRole('link', { name: 'Skatten din for 2022' }).click();
+    await page.getByRole('button', { name: 'Tilbake' }).click();
+    await expect(page.getByRole('button', { name: 'Test Testesen' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Test Testesen' }).click();
+    await page.locator('li').filter({ hasText: 'Firma AS' }).click();
+
+    await expect(page.getByRole('button', { name: 'Firma AS' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Firma AS' })).toBeVisible();
+    await page.getByRole('link', { name: 'This is a message 1 for Firma AS' }).click();
+    await page.getByRole('button', { name: 'Tilbake' }).click();
+    await expect(page.getByRole('button', { name: 'Firma AS' })).toBeVisible();
+    await expect(page.getByTestId('pageLayout-background')).toHaveClass(/.*isCompany.*/);
+    expect(new URL(page.url()).searchParams.has('party')).toBe(true);
+
+    await page.getByRole('button', { name: 'Firma AS' }).click();
+    await page.locator('li').filter({ hasText: 'Alle virksomheter' }).click();
+    await expect(page.getByRole('button', { name: 'Alle virksomheter' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Firma AS' })).toBeVisible();
+    await page.getByRole('link', { name: 'This is a message 1 for Firma AS' }).click();
+    await page.getByRole('button', { name: 'Tilbake' }).click();
+    await expect(page.getByRole('button', { name: 'Alle virksomheter' })).toBeVisible();
+    await expect(page.getByTestId('pageLayout-background')).toHaveClass(/.*isCompany.*/);
+  });
+
+  test('Back button navigates to previous page the message has been opened from', async ({ page }) => {
+    await page.goto(pageWithMockOrganizations);
+
+    await expect(page.locator('h2').filter({ hasText: /^Skatten din for 2022$/ })).toBeVisible();
+    await page.getByRole('link', { name: 'Skatten din for 2022' }).click();
+    await page.getByRole('button', { name: 'Flytt til papirkurv' }).click();
+
+    await page.getByRole('link', { name: 'Papirkurv' }).click();
+    await page.getByRole('link', { name: 'Skatten din for 2022' }).click();
+    await page.getByRole('button', { name: 'Tilbake' }).click();
+    await expect(page.getByRole('heading', { name: 'i papirkurv' })).toBeVisible();
+  });
+});

--- a/packages/storybook/src/stories/BackButton/backButton.stories.tsx
+++ b/packages/storybook/src/stories/BackButton/backButton.stories.tsx
@@ -14,6 +14,6 @@ export default {
 
 export const Default: StoryObj<typeof BackButton> = {
   args: {
-    pathTo: '/',
+    path: '/',
   },
 };


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

#1373 

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- The `BackButton` component now accepts a simplified prop structure for improved usability.
	- The `SavedSearchesItem` component utilizes `Link` components for navigation, enhancing routing consistency.
	- The `InboxItem` component now requires a `linkTo` prop, ensuring clearer navigation intent.
	- Enhanced navigation behavior in the `InboxItemPage` with contextually relevant back navigation.

- **Bug Fixes**
	- Streamlined the `BackButton` usage by removing unnecessary props, simplifying user interaction.

- **Tests**
	- Introduced a new test suite for message navigation, verifying the functionality of the back button and ensuring the correct saving of party context during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->