### PR TITLE
fix: autocomplete not working when searching within scope of inbox

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -21,7 +21,7 @@
     "i18n:sort": "tsx ./src/i18n/check.ts --sort"
   },
   "dependencies": {
-    "@altinn/altinn-components": "^0.8.3",
+    "@altinn/altinn-components": "^0.9.1",
     "@digdir/designsystemet-css": "0.11.0-next.10",
     "@digdir/designsystemet-react": "1.0.0-next.15",
     "@digdir/designsystemet-theme": "1.0.0-next.14",

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -88,10 +88,7 @@ export const PageLayout: React.FC = () => {
       onChange: (event: ChangeEvent<HTMLInputElement>) => setSearchValue(event.target.value),
       autocomplete: {
         ...autocomplete,
-        items: autocomplete.items.map((item) => ({
-          ...item,
-          onClick: () => onClear(),
-        })),
+        items: autocomplete.items,
       },
     },
     menu: {

--- a/packages/frontend/src/components/PageLayout/Search/useSearchDialogs.tsx
+++ b/packages/frontend/src/components/PageLayout/Search/useSearchDialogs.tsx
@@ -5,7 +5,7 @@ import { useDebounce } from 'use-debounce';
 import { mapDialogDtoToInboxItem, searchDialogs } from '../../../api/useDialogs.tsx';
 import { QUERY_KEYS } from '../../../constants/queryKeys.ts';
 import { useOrganizations } from '../../../pages/Inbox/useOrganizations.ts';
-import type { InboxItemInput } from '../../InboxItem/InboxItem.tsx';
+import type { InboxItemInput } from '../../InboxItem';
 
 interface searchDialogsProps {
   parties: PartyFieldsFragment[];

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -22,7 +22,7 @@ import { useSearchDialogs, useSearchString } from '../../components/PageLayout/S
 import { SaveSearchButton } from '../../components/SavedSearchButton/SaveSearchButton.tsx';
 import { FeatureFlagKeys, useFeatureFlag } from '../../featureFlags';
 import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
-import { handleSaveSearch } from '../SavedSearches/SavedSearchesPage.tsx';
+import { handleSaveSearch } from '../SavedSearches';
 import { InboxSkeleton } from './InboxSkeleton.tsx';
 import { filterDialogs, getFilterBarSettings } from './filters.ts';
 import styles from './inbox.module.css';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,8 +398,8 @@ importers:
   packages/frontend:
     dependencies:
       '@altinn/altinn-components':
-        specifier: ^0.8.3
-        version: 0.8.3(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^0.9.1
+        version: 0.9.1(react-dom@18.3.1)(react@18.3.1)
       '@digdir/designsystemet-css':
         specifier: 0.11.0-next.10
         version: 0.11.0-next.10
@@ -843,8 +843,8 @@ packages:
       '@algolia/requester-common': 4.24.0
     dev: false
 
-  /@altinn/altinn-components@0.8.3(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-ImtNguhcHF8geGz0gNl8pc/fmOiAmlxw+zy9ucU8iuxtzcF16tPCFicsWwzSDJf/Rzk4gG+viKVL7qbi6/e6EQ==}
+  /@altinn/altinn-components@0.9.1(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-ZyWUIFRRy6xNmdpiz8K8duJYTx8lcf0GajcVpc3zWwGwpiucu6ovpz7bD8uVEdzoCqNeF33JnavGQbs5INTlFQ==}
     peerDependencies:
       react: '>=18.3.1'
       react-dom: '>=18.3.1'


### PR DESCRIPTION
- onClick on autocomplete items were overridden by on clear in PageLayout (Probably some experimental code that was forgotten?) and re-introduces onClick which was easily missed during a merge conflict after refactoring,

- Since it uses a later version of altinn-components, it includes https://github.com/Altinn/altinn-components/issues/116:
(Layout body should be hidden on mobile when menu is open)

- remove old copy of useSearchDialogs (not in use)


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
