### PR TITLE
fix: autocomplete includes results for sub parties belonging to selected party

### DIFF
--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -38,7 +38,7 @@ export const PageLayout: React.FC = () => {
   const { searchValue, setSearchValue, onClear } = useSearchString();
   const { selectedProfile, selectedParties, parties, selectedPartyIds, setSelectedPartyIds } = useParties();
   const { dialogs } = useDialogs(parties);
-  const { autocomplete } = useSearchAutocompleteDialogs({ parties: selectedParties, searchValue });
+  const { autocomplete } = useSearchAutocompleteDialogs({ selectedParties: selectedParties, searchValue });
   const { accounts, selectedAccount, accountSearch, accountGroups } = useAccounts({
     parties,
     selectedParties,

--- a/packages/frontend/src/components/PageLayout/Search/useSearchAutocompleteDialogs.tsx
+++ b/packages/frontend/src/components/PageLayout/Search/useSearchAutocompleteDialogs.tsx
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
 import {
   type SearchAutocompleteDialogInput,
+  flattenParties,
   mapAutocompleteDialogsDtoToInboxItem,
   searchAutocompleteDialogs,
 } from '../../../api/useDialogs.tsx';
@@ -15,7 +16,7 @@ import { QUERY_KEYS } from '../../../constants/queryKeys.ts';
 import { useSearchString } from './useSearchString.tsx';
 
 interface searchDialogsProps {
-  parties: PartyFieldsFragment[];
+  selectedParties: PartyFieldsFragment[];
   searchValue?: string;
   status?: DialogStatus;
 }
@@ -126,13 +127,13 @@ interface UseAutocompleteDialogsOutput {
 }
 
 export const useSearchAutocompleteDialogs = ({
-  parties,
+  selectedParties,
   searchValue,
 }: searchDialogsProps): UseAutocompleteDialogsOutput => {
-  const partyURIs = parties.map((party) => party.party);
+  const partyURIs = flattenParties(selectedParties);
   const debouncedSearchString = useDebounce(searchValue, 300)[0];
   const { onSearch } = useSearchString();
-  const enabled = !!debouncedSearchString && debouncedSearchString.length > 2 && parties.length > 0;
+  const enabled = !!debouncedSearchString && debouncedSearchString.length > 2 && selectedParties.length > 0;
   const {
     data: hits,
     isSuccess,

--- a/packages/frontend/tests/stories/flatPartySubParty.spec.ts
+++ b/packages/frontend/tests/stories/flatPartySubParty.spec.ts
@@ -46,8 +46,7 @@ test.describe('Flattened parties and subparties', () => {
       page.getByTestId('main-header').getByRole('link', { name: 'Message for Test Testesen' }),
     ).not.toBeVisible();
     await expect(page.getByRole('link', { name: 'Main party message Main' })).toBeVisible();
-    //TO-DO fix search should not filter out sub party messages #1562
-    // await expect(page.getByRole('link', { name: 'Sub party message' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Sub party message' })).toBeVisible();
 
     await page.getByPlaceholder('Søk').press('Enter');
   });


### PR DESCRIPTION
It also contains a modified response from `getSearchAutocompleteDialogs` to confirm to the exact response (`SearchAutocompleteDialogFieldsFragment`) we fetch from dialogporten. 

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

#1562 

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
