### PR TITLE
fix: flattened subparties were undefined when subparty list was empty

### DIFF
--- a/packages/frontend/src/api/useDialogs.tsx
+++ b/packages/frontend/src/api/useDialogs.tsx
@@ -116,7 +116,7 @@ export const getDialogs = (partyURIs: string[]): Promise<GetAllDialogsForParties
 
 export const flattenParties = (partiesToUse: PartyFieldsFragment[]) => {
   const partyURIs = partiesToUse.map((party) => party.party);
-  const subPartyURIs = partiesToUse.flatMap((party) => party.subParties?.map((subParty) => subParty.party));
+  const subPartyURIs = partiesToUse.flatMap((party) => (party.subParties ?? []).map((subParty) => subParty.party));
   return [...partyURIs, ...subPartyURIs] as string[];
 };
 

--- a/packages/frontend/src/mocks/data/stories/dialog-count/dialogs.ts
+++ b/packages/frontend/src/mocks/data/stories/dialog-count/dialogs.ts
@@ -1,0 +1,616 @@
+import {ActorType, DialogStatus, type SearchDialogFieldsFragment, SystemLabel} from 'bff-types-generated';
+
+
+export const dialogs: SearchDialogFieldsFragment[] = [
+  {
+    "id": "01939be3-f112-75fe-a039-458acc1612bd",
+    "party": "urn:altinn:organization:identifier-no:314518748",
+    "org": "dmf",
+    "progress": 10,
+    "guiAttachmentCount": 1,
+    "status": DialogStatus.New,
+    "createdAt": "2024-12-06T12:13:47.153Z",
+    "updatedAt": "2024-12-06T12:13:47.153Z",
+    "extendedStatus": null,
+    "seenSinceLastUpdate": [],
+    "latestActivity": {
+      "description": [
+        {
+          "value": "Form created and pre-filled",
+          "languageCode": "en"
+        },
+        {
+          "value": "Skjema opprettet og forhåndsutfylt",
+          "languageCode": "nb"
+        }
+      ],
+      "performedBy": {
+        "actorType": ActorType.ServiceOwner,
+        "actorId": null,
+        "actorName": null
+      }
+    },
+    "content": {
+      "title": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "VassenDialog",
+            "languageCode": "en"
+          },
+          {
+            "value": "Dialog for DMF",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "summary": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "A summary here. Max 200 characters, no HTML support. Required. Displayed in list.",
+            "languageCode": "en"
+          },
+          {
+            "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "senderName": null,
+      "extendedStatus": null
+    },
+    "systemLabel": SystemLabel.Default
+  },
+  {
+    "id": "01939be3-7990-73a5-9d74-2c73da20944d",
+    "party": "urn:altinn:organization:identifier-no:312409216",
+    "org": "dmf",
+    "progress": 10,
+    "guiAttachmentCount": 1,
+    "status": DialogStatus.New,
+    "createdAt": "2024-12-06T12:13:16.560Z",
+    "updatedAt": "2024-12-06T12:13:16.560Z",
+    "extendedStatus": null,
+    "seenSinceLastUpdate": [],
+    "latestActivity": {
+      "description": [
+        {
+          "value": "Form created and pre-filled",
+          "languageCode": "en"
+        },
+        {
+          "value": "Skjema opprettet og forhåndsutfylt",
+          "languageCode": "nb"
+        }
+      ],
+      "performedBy": {
+        "actorType": ActorType.ServiceOwner,
+        "actorId": null,
+        "actorName": null
+      }
+    },
+    "content": {
+      "title": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "VassenDialog",
+            "languageCode": "en"
+          },
+          {
+            "value": "Dialog for DMF",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "summary": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "A summary here. Max 200 characters, no HTML support. Required. Displayed in list.",
+            "languageCode": "en"
+          },
+          {
+            "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "senderName": null,
+      "extendedStatus": null
+    },
+    "systemLabel": SystemLabel.Default,
+  },
+  {
+    "id": "01939be3-131e-739d-ad97-119614c6d3c6",
+    "party": "urn:altinn:organization:identifier-no:315073693",
+    "org": "dmf",
+    "progress": 10,
+    "guiAttachmentCount": 1,
+    "status": DialogStatus.New,
+    "createdAt": "2024-12-06T12:12:50.334Z",
+    "updatedAt": "2024-12-06T12:12:50.334Z",
+    "extendedStatus": null,
+    "seenSinceLastUpdate": [],
+    "latestActivity": {
+      "description": [
+        {
+          "value": "Form created and pre-filled",
+          "languageCode": "en"
+        },
+        {
+          "value": "Skjema opprettet og forhåndsutfylt",
+          "languageCode": "nb"
+        }
+      ],
+      "performedBy": {
+        "actorType": ActorType.ServiceOwner,
+        "actorId": null,
+        "actorName": null
+      }
+    },
+    "content": {
+      "title": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "VassenDialog",
+            "languageCode": "en"
+          },
+          {
+            "value": "Dialog for DMF",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "summary": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "A summary here. Max 200 characters, no HTML support. Required. Displayed in list.",
+            "languageCode": "en"
+          },
+          {
+            "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "senderName": null,
+      "extendedStatus": null
+    },
+    "systemLabel": SystemLabel.Default
+  },
+  {
+    "id": "01939be2-817c-7426-9ad7-1d598c6caf16",
+    "party": "urn:altinn:organization:identifier-no:313776816",
+    "org": "dmf",
+    "progress": 10,
+    "guiAttachmentCount": 1,
+    "status": DialogStatus.New,
+    "createdAt": "2024-12-06T12:12:13.052Z",
+    "updatedAt": "2024-12-06T12:12:13.052Z",
+    "extendedStatus": null,
+    "seenSinceLastUpdate": [],
+    "latestActivity": {
+      "description": [
+        {
+          "value": "Form created and pre-filled",
+          "languageCode": "en"
+        },
+        {
+          "value": "Skjema opprettet og forhåndsutfylt",
+          "languageCode": "nb"
+        }
+      ],
+      "performedBy": {
+        "actorType": ActorType.ServiceOwner,
+        "actorId": null,
+        "actorName": null
+      }
+    },
+    "content": {
+      "title": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "VassenDialog",
+            "languageCode": "en"
+          },
+          {
+            "value": "Dialog for DMF",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "summary": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "A summary here. Max 200 characters, no HTML support. Required. Displayed in list.",
+            "languageCode": "en"
+          },
+          {
+            "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "senderName": null,
+      "extendedStatus": null
+    },
+    "systemLabel": SystemLabel.Default,
+  },
+  {
+    "id": "01939be2-1b72-744e-a972-978f88f7829a",
+    "party": "urn:altinn:organization:identifier-no:311615688",
+    "org": "dmf",
+    "progress": 10,
+    "guiAttachmentCount": 1,
+    "status": DialogStatus.New,
+    "createdAt": "2024-12-06T12:11:46.929Z",
+    "updatedAt": "2024-12-06T12:11:46.929Z",
+    "extendedStatus": null,
+    "seenSinceLastUpdate": [],
+    "latestActivity": {
+      "description": [
+        {
+          "value": "Form created and pre-filled",
+          "languageCode": "en"
+        },
+        {
+          "value": "Skjema opprettet og forhåndsutfylt",
+          "languageCode": "nb"
+        }
+      ],
+      "performedBy": {
+        "actorType": ActorType.ServiceOwner,
+        "actorId": null,
+        "actorName": null
+      }
+    },
+    "content": {
+      "title": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "VassenDialog",
+            "languageCode": "en"
+          },
+          {
+            "value": "Dialog for DMF",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "summary": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "A summary here. Max 200 characters, no HTML support. Required. Displayed in list.",
+            "languageCode": "en"
+          },
+          {
+            "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "senderName": null,
+      "extendedStatus": null
+    },
+    "systemLabel": SystemLabel.Default,
+  },
+  {
+    "id": "01939be1-abaa-70e7-9301-2c96e773145c",
+    "party": "urn:altinn:organization:identifier-no:311615696",
+    "org": "dmf",
+    "progress": 10,
+    "guiAttachmentCount": 1,
+    "status": DialogStatus.New,
+    "createdAt": "2024-12-06T12:11:18.314Z",
+    "updatedAt": "2024-12-06T12:11:18.314Z",
+    "extendedStatus": null,
+    "seenSinceLastUpdate": [],
+    "latestActivity": {
+      "description": [
+        {
+          "value": "Form created and pre-filled",
+          "languageCode": "en"
+        },
+        {
+          "value": "Skjema opprettet og forhåndsutfylt",
+          "languageCode": "nb"
+        }
+      ],
+      "performedBy": {
+        "actorType":ActorType.ServiceOwner,
+        "actorId": null,
+        "actorName": null
+      }
+    },
+    "content": {
+      "title": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "VassenDialog",
+            "languageCode": "en"
+          },
+          {
+            "value": "Dialog for DMF",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "summary": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "A summary here. Max 200 characters, no HTML support. Required. Displayed in list.",
+            "languageCode": "en"
+          },
+          {
+            "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "senderName": null,
+      "extendedStatus": null
+    },
+    "systemLabel": SystemLabel.Default,
+  },
+  {
+    "id": "01939be1-3fc5-775e-8b7f-7710b348d210",
+    "party": "urn:altinn:organization:identifier-no:313549461",
+    "org": "dmf",
+    "progress": 10,
+    "guiAttachmentCount": 1,
+    "status": DialogStatus.New,
+    "createdAt": "2024-12-06T12:10:50.693Z",
+    "updatedAt": "2024-12-06T12:10:50.693Z",
+    "extendedStatus": null,
+    "seenSinceLastUpdate": [],
+    "latestActivity": {
+      "description": [
+        {
+          "value": "Form created and pre-filled",
+          "languageCode": "en"
+        },
+        {
+          "value": "Skjema opprettet og forhåndsutfylt",
+          "languageCode": "nb"
+        }
+      ],
+      "performedBy": {
+        "actorType": ActorType.ServiceOwner,
+        "actorId": null,
+        "actorName": null
+      }
+    },
+    "content": {
+      "title": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "VassenDialog",
+            "languageCode": "en"
+          },
+          {
+            "value": "Dialog for DMF",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "summary": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "A summary here. Max 200 characters, no HTML support. Required. Displayed in list.",
+            "languageCode": "en"
+          },
+          {
+            "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "senderName": null,
+      "extendedStatus": null
+    },
+    "systemLabel": SystemLabel.Default,
+  },
+  {
+    "id": "01939be0-a01f-71bb-8f01-9a3bbeaf3324",
+    "party": "urn:altinn:organization:identifier-no:215421902",
+    "org": "dmf",
+    "progress": 10,
+    "guiAttachmentCount": 1,
+    "status": DialogStatus.New,
+    "createdAt": "2024-12-06T12:10:09.823Z",
+    "updatedAt": "2024-12-06T12:10:09.823Z",
+    "extendedStatus": null,
+    "seenSinceLastUpdate": [],
+    "latestActivity": {
+      "description": [
+        {
+          "value": "Form created and pre-filled",
+          "languageCode": "en"
+        },
+        {
+          "value": "Skjema opprettet og forhåndsutfylt",
+          "languageCode": "nb"
+        }
+      ],
+      "performedBy": {
+        "actorType": ActorType.ServiceOwner,
+        "actorId": null,
+        "actorName": null
+      }
+    },
+    "content": {
+      "title": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "VassenDialog",
+            "languageCode": "en"
+          },
+          {
+            "value": "Dialog for DMF",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "summary": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "A summary here. Max 200 characters, no HTML support. Required. Displayed in list.",
+            "languageCode": "en"
+          },
+          {
+            "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "senderName": null,
+      "extendedStatus": null
+    },
+    "systemLabel": SystemLabel.Default,
+  },
+  {
+    "id": "01939be0-15e1-72ab-8261-2798d078b57c",
+    "party": "urn:altinn:organization:identifier-no:213294342",
+    "org": "dmf",
+    "progress": 10,
+    "guiAttachmentCount": 1,
+    "status": DialogStatus.New,
+    "createdAt": "2024-12-06T12:09:34.433Z",
+    "updatedAt": "2024-12-06T12:09:34.433Z",
+    "extendedStatus": null,
+    "seenSinceLastUpdate": [],
+    "latestActivity": {
+      "description": [
+        {
+          "value": "Form created and pre-filled",
+          "languageCode": "en"
+        },
+        {
+          "value": "Skjema opprettet og forhåndsutfylt",
+          "languageCode": "nb"
+        }
+      ],
+      "performedBy": {
+        "actorType": ActorType.ServiceOwner,
+        "actorId": null,
+        "actorName": null
+      }
+    },
+    "content": {
+      "title": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "VassenDialog",
+            "languageCode": "en"
+          },
+          {
+            "value": "Dialog for DMF",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "summary": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "A summary here. Max 200 characters, no HTML support. Required. Displayed in list.",
+            "languageCode": "en"
+          },
+          {
+            "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "senderName": null,
+      "extendedStatus": null
+    },
+    "systemLabel": SystemLabel.Default,
+  },
+  {
+    "id": "01939b61-8b48-778b-8132-b94bc5f05484",
+    "party": "urn:altinn:person:identifier-no:12907499179",
+    "org": "dmf",
+    "progress": 10,
+    "guiAttachmentCount": 1,
+    "status": DialogStatus.New,
+    "createdAt": "2024-12-06T09:51:21.416Z",
+    "updatedAt": "2024-12-06T09:51:21.416Z",
+    "extendedStatus": null,
+    "seenSinceLastUpdate": [
+      {
+        "id": "0193b090-a7cd-74ad-8d89-b46e4cc8ec22",
+        "seenAt": "2024-12-10T12:34:50.445Z",
+        "seenBy": {
+          "actorType": ActorType.PartyRepresentative,
+          "actorId": "urn:altinn:person:identifier-ephemeral:839200eb6a",
+          "actorName": "ASK UGLESETT"
+        },
+        "isCurrentEndUser": true
+      }
+    ],
+    "latestActivity": {
+      "description": [
+        {
+          "value": "Form created and pre-filled",
+          "languageCode": "en"
+        },
+        {
+          "value": "Skjema opprettet og forhåndsutfylt",
+          "languageCode": "nb"
+        }
+      ],
+      "performedBy": {
+        "actorType": ActorType.ServiceOwner,
+        "actorId": null,
+        "actorName": null
+      }
+    },
+    "content": {
+      "title": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "VassenDialog",
+            "languageCode": "en"
+          },
+          {
+            "value": "Dialog for DMF",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "summary": {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "A summary here. Max 200 characters, no HTML support. Required. Displayed in list.",
+            "languageCode": "en"
+          },
+          {
+            "value": "Et sammendrag her. Maks 200 tegn, ingen HTML-støtte. Påkrevd. Vises i liste.",
+            "languageCode": "nb"
+          }
+        ]
+      },
+      "senderName": null,
+      "extendedStatus": null
+    },
+    "systemLabel": SystemLabel.Default,
+  }
+]

--- a/packages/frontend/src/mocks/data/stories/dialog-count/parties.ts
+++ b/packages/frontend/src/mocks/data/stories/dialog-count/parties.ts
@@ -1,0 +1,103 @@
+import type { PartyFieldsFragment } from 'bff-types-generated';
+
+export const parties: PartyFieldsFragment[] = [
+  {
+    "party": "urn:altinn:person:identifier-no:12907499179",
+    "partyType": "Person",
+    "subParties": [],
+    "isAccessManager": true,
+    "isMainAdministrator": false,
+    "name": "ASK UGLESETT",
+    "isCurrentEndUser": true,
+    "isDeleted": false
+  },
+  {
+    "party": "urn:altinn:organization:identifier-no:213294342",
+    "partyType": "Organization",
+    "subParties": [
+      {
+        "party": "urn:altinn:organization:identifier-no:215421902",
+        "partyType": "Organization",
+        "isAccessManager": true,
+        "isMainAdministrator": true,
+        "name": "LATTERMILD ORIENTAL TIGER AS",
+        "isCurrentEndUser": false,
+        "isDeleted": false
+      }
+    ],
+    "isAccessManager": true,
+    "isMainAdministrator": true,
+    "name": "LATTERMILD ORIENTAL TIGER AS",
+    "isCurrentEndUser": false,
+    "isDeleted": false
+  },
+  {
+    "party": "urn:altinn:organization:identifier-no:313549461",
+    "partyType": "Organization",
+    "subParties": [
+      {
+        "party": "urn:altinn:organization:identifier-no:311615696",
+        "partyType": "Organization",
+        "isAccessManager": true,
+        "isMainAdministrator": true,
+        "name": "DYPSINDIG FUNKSJONELL FJELLREV",
+        "isCurrentEndUser": false,
+        "isDeleted": false
+      },
+      {
+        "party": "urn:altinn:organization:identifier-no:311615688",
+        "partyType": "Organization",
+        "isAccessManager": true,
+        "isMainAdministrator": true,
+        "name": "UPRESIS KONSENTRISK FJELLREV",
+        "isCurrentEndUser": false,
+        "isDeleted": false
+      }
+    ],
+    "isAccessManager": true,
+    "isMainAdministrator": true,
+    "name": "ORDENTLIG VIRTUELL TIGER AS",
+    "isCurrentEndUser": false,
+    "isDeleted": false
+  },
+  {
+    "party": "urn:altinn:organization:identifier-no:313776816",
+    "partyType": "Organization",
+    "subParties": [
+      {
+        "party": "urn:altinn:organization:identifier-no:315073693",
+        "partyType": "Organization",
+        "isAccessManager": false,
+        "isMainAdministrator": false,
+        "name": "PLUTSELIG NYBAKT TIGER AS",
+        "isCurrentEndUser": false,
+        "isDeleted": false
+      }
+    ],
+    "isAccessManager": false,
+    "isMainAdministrator": false,
+    "name": "PLUTSELIG NYBAKT TIGER AS",
+    "isCurrentEndUser": false,
+    "isDeleted": false
+  },
+  {
+    "party": "urn:altinn:organization:identifier-no:312409216",
+    "partyType": "Organization",
+    "subParties": [
+      {
+        "party": "urn:altinn:organization:identifier-no:314518748",
+        "partyType": "Organization",
+        "isAccessManager": false,
+        "isMainAdministrator": false,
+        "name": "STYRBAR UTTRYKKSFULL TIGER AS",
+        "isCurrentEndUser": false,
+        "isDeleted": false
+      }
+    ],
+    "isAccessManager": false,
+    "isMainAdministrator": false,
+    "name": "STYRBAR UTTRYKKSFULL TIGER AS",
+    "isCurrentEndUser": false,
+    "isDeleted": false
+  }
+]


### PR DESCRIPTION
I also added correct response to mock handler when party list is empty or invalid party id.


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

#1492

### Dokumentasjon / Storybook / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Ny komponent har en eller flere `stories` i `Storybook`, eller så er ikke dette relevant.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
